### PR TITLE
*: Rename to prometheus-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Implement `Gauge::dec` and `Gauge::dec_by`. See [PR 30].
 
-[PR 28]: https://github.com/mxinden/rust-open-metrics-client/pull/28
-[PR 27]: https://github.com/mxinden/rust-open-metrics-client/pull/27
-[PR 30]: https://github.com/mxinden/rust-open-metrics-client/pull/30
+[PR 28]: https://github.com/prometheus/client_rust/pull/28
+[PR 27]: https://github.com/prometheus/client_rust/pull/27
+[PR 30]: https://github.com/prometheus/client_rust/pull/30
 
 ## [0.13.0] - 2021-11-21
 
@@ -28,8 +28,8 @@ including a breaking change. See [PR 24] for details._
 
 - Allow family to use constructors that do not coerce to function pointers. See [PR 21].
 
-[PR 21]: https://github.com/mxinden/rust-open-metrics-client/pull/21
-[PR 24]: https://github.com/mxinden/rust-open-metrics-client/pull/24
+[PR 21]: https://github.com/prometheus/client_rust/pull/21
+[PR 24]: https://github.com/prometheus/client_rust/pull/24
 
 ## [0.12.0] - 2021-08-07
 
@@ -42,7 +42,7 @@ including a breaking change. See [PR 24] for details._
 - Rename `Registry::sub_registry` to `Registry::sub_registry_with_prefix`. See
   [PR 20].
 
-[PR 20]: https://github.com/mxinden/rust-open-metrics-client/pull/20
+[PR 20]: https://github.com/prometheus/client_rust/pull/20
 
 ## [0.11.2] - 2021-06-09
 ### Fixed
@@ -56,24 +56,24 @@ including a breaking change. See [PR 24] for details._
 ### Added
 - Add support for OpenMetrics Info metrics (see [PR 18]).
 
-[PR 18]: https://github.com/mxinden/rust-open-metrics-client/pull/18
+[PR 18]: https://github.com/prometheus/client_rust/pull/18
 
 ## [0.10.1] - 2021-05-31
 ### Added
 - Implement `Encode` for `u32`.
 
 ### Fixed
-- Update to open-metrics-client-derive-text-encode v0.1.1 which handles keyword
+- Update to prometheus-client-derive-text-encode v0.1.1 which handles keyword
   identifiers aka raw identifiers
 
-  https://github.com/mxinden/rust-open-metrics-client/pull/16
+  https://github.com/prometheus/client_rust/pull/16
 
 ## [0.10.0] - 2021-04-29
 ### Added
 - Added `metrics::histogram::linear_buckets`.
-  https://github.com/mxinden/rust-open-metrics-client/issues/13
+  https://github.com/prometheus/client_rust/issues/13
 
 ### Changed
 - Renamed `metrics::histogram::exponential_series` to
   `metrics::histogram::exponential_buckets`.
-  https://github.com/mxinden/rust-open-metrics-client/issues/13
+  https://github.com/prometheus/client_rust/issues/13

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "open-metrics-client"
+name = "prometheus-client"
 version = "0.14.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2018"
 description = "Open Metrics client library allowing users to natively instrument applications."
 license = "Apache-2.0 OR MIT"
 keywords = ["openmetrics", "prometheus", "metrics", "instrumentation", "monitoring"]
-repository = "https://github.com/mxinden/rust-open-metrics-client"
-homepage = "https://github.com/mxinden/rust-open-metrics-client"
-documentation = "https://docs.rs/open-metrics-client"
+repository = "https://github.com/prometheus/client_rust"
+homepage = "https://github.com/prometheus/client_rust"
+documentation = "https://docs.rs/prometheus-client"
 
 [workspace]
 members = ["derive-text-encode"]
@@ -17,7 +17,7 @@ members = ["derive-text-encode"]
 dtoa = "1.0"
 itoa = "1.0"
 owning_ref = "0.4"
-open-metrics-client-derive-text-encode = { version = "0.1.1", path = "derive-text-encode" }
+prometheus-client-derive-text-encode = { version = "0.1.1", path = "derive-text-encode" }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Open Metrics Client Library
+# Prometheus Rust client library
 
-[![Test Status](https://github.com/mxinden/rust-open-metrics-client/actions/workflows/rust.yml/badge.svg?event=push)](https://github.com/mxinden/rust-open-metrics-client/actions)
-[![Crate](https://img.shields.io/crates/v/open-metrics-client.svg)](https://crates.io/crates/open-metrics-client)
-[![API](https://docs.rs/open-metrics-client/badge.svg)](https://docs.rs/open-metrics-client)
+[![Test Status](https://github.com/prometheus/client_rust/actions/workflows/rust.yml/badge.svg?event=push)](https://github.com/prometheus/client_rust/actions)
+[![Crate](https://img.shields.io/crates/v/prometheus-client.svg)](https://crates.io/crates/prometheus-client)
+[![API](https://docs.rs/prometheus-client/badge.svg)](https://docs.rs/prometheus-client)
 
 [Rust](https://github.com/rust-lang/) client library implementation of the [Open
 Metrics specification](https://github.com/OpenObservability/OpenMetrics). Allows
 developers to instrument applications and thus enables operators to monitor said
 applications with monitoring systems like [Prometheus](https://prometheus.io/).
 
-**Documentation**: https://docs.rs/open-metrics-client/
+**Documentation**: https://docs.rs/prometheus-client/
 
 ## Goals
 

--- a/benches/encoding/text.rs
+++ b/benches/encoding/text.rs
@@ -1,11 +1,11 @@
 // Benchmark inspired by https://github.com/tikv/rust-prometheus/blob/ab1ca7285d3463504381a5025ae1951e020d6796/benches/text_encoder.rs
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use open_metrics_client::encoding::text::{encode, Encode, EncodeMetric};
-use open_metrics_client::metrics::counter::Counter;
-use open_metrics_client::metrics::family::Family;
-use open_metrics_client::metrics::histogram::{exponential_buckets, Histogram};
-use open_metrics_client::registry::Registry;
+use prometheus_client::encoding::text::{encode, Encode, EncodeMetric};
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
+use prometheus_client::registry::Registry;
 use std::io::Write;
 use std::sync::atomic::AtomicU64;
 

--- a/benches/family.rs
+++ b/benches/family.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use open_metrics_client::metrics::counter::Counter;
-use open_metrics_client::metrics::family::Family;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
 
 pub fn family(c: &mut Criterion) {
     c.bench_function("counter family with Vec<(String, String)> label set", |b| {

--- a/derive-text-encode/Cargo.toml
+++ b/derive-text-encode/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "open-metrics-client-derive-text-encode"
+name = "prometheus-client-derive-text-encode"
 version = "0.1.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2018"
-description = "Auxiliary crate to derive text Encode trait from open-metrics-client."
+description = "Auxiliary crate to derive text Encode trait from prometheus-client."
 license = "Apache-2.0 OR MIT"
-repository = "https://github.com/mxinden/rust-open-metrics-client"
-homepage = "https://github.com/mxinden/rust-open-metrics-client"
-documentation = "https://docs.rs/open-metrics-client-derive-text-encode"
+repository = "https://github.com/prometheus/client_rust"
+homepage = "https://github.com/prometheus/client_rust"
+documentation = "https://docs.rs/prometheus-client-derive-text-encode"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,7 +17,7 @@ quote = "1"
 syn = "1"
 
 [dev-dependencies]
-open-metrics-client = { path = "../" }
+prometheus-client = { path = "../" }
 
 [lib]
 proc-macro = true

--- a/derive-text-encode/src/lib.rs
+++ b/derive-text-encode/src/lib.rs
@@ -31,7 +31,7 @@ pub fn derive_encode(input: TokenStream) -> TokenStream {
                     quote! {
                         #maybe_comma
                         writer.write_all(concat!(#ident_string, "=\"").as_bytes())?;
-                        open_metrics_client::encoding::text::Encode::encode(&self.#ident, writer)?;
+                        prometheus_client::encoding::text::Encode::encode(&self.#ident, writer)?;
                         writer.write_all(b"\"")?;
                     }
                 })
@@ -62,7 +62,7 @@ pub fn derive_encode(input: TokenStream) -> TokenStream {
     };
 
     let gen = quote! {
-        impl open_metrics_client::encoding::text::Encode for #name {
+        impl prometheus_client::encoding::text::Encode for #name {
             fn encode(&self, writer: &mut dyn std::io::Write) -> std::result::Result<(), std::io::Error> {
                 #body
 

--- a/derive-text-encode/tests/lib.rs
+++ b/derive-text-encode/tests/lib.rs
@@ -1,7 +1,7 @@
-use open_metrics_client::encoding::text::{encode, Encode};
-use open_metrics_client::metrics::counter::Counter;
-use open_metrics_client::metrics::family::Family;
-use open_metrics_client::registry::Registry;
+use prometheus_client::encoding::text::{encode, Encode};
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::registry::Registry;
 
 #[test]
 fn basic_flow() {

--- a/examples/tide.rs
+++ b/examples/tide.rs
@@ -1,7 +1,7 @@
-use open_metrics_client::encoding::text::{encode, Encode};
-use open_metrics_client::metrics::counter::Counter;
-use open_metrics_client::metrics::family::Family;
-use open_metrics_client::registry::Registry;
+use prometheus_client::encoding::text::{encode, Encode};
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::registry::Registry;
 
 use std::sync::{Arc, Mutex};
 

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -1,9 +1,9 @@
 //! Open Metrics text format implementation.
 //!
 //! ```
-//! # use open_metrics_client::encoding::text::encode;
-//! # use open_metrics_client::metrics::counter::Counter;
-//! # use open_metrics_client::registry::Registry;
+//! # use prometheus_client::encoding::text::encode;
+//! # use prometheus_client::metrics::counter::Counter;
+//! # use prometheus_client::registry::Registry;
 //! #
 //! # // Create registry and counter and register the latter with the former.
 //! # let mut registry = Registry::default();
@@ -38,7 +38,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::ops::Deref;
 
-pub use open_metrics_client_derive_text_encode::*;
+pub use prometheus_client_derive_text_encode::*;
 
 pub fn encode<W, M>(writer: &mut W, registry: &Registry<M>) -> Result<(), std::io::Error>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,11 @@
 //! # Examples
 //!
 //! ```
-//! # use open_metrics_client::encoding::text::Encode;
-//! # use open_metrics_client::encoding::text::encode;
-//! # use open_metrics_client::metrics::counter::{Atomic, Counter};
-//! # use open_metrics_client::metrics::family::Family;
-//! # use open_metrics_client::registry::Registry;
+//! # use prometheus_client::encoding::text::Encode;
+//! # use prometheus_client::encoding::text::encode;
+//! # use prometheus_client::metrics::counter::{Atomic, Counter};
+//! # use prometheus_client::metrics::family::Family;
+//! # use prometheus_client::registry::Registry;
 //! # use std::io::Write;
 //! #
 //! // Create a metric registry.
@@ -74,7 +74,7 @@
 //! ```
 //! See [examples] directory for more.
 //!
-//! [examples]: https://github.com/mxinden/rust-open-metrics-client/tree/master/examples
+//! [examples]: https://github.com/prometheus/client_rust/tree/master/examples
 
 pub mod encoding;
 pub mod metrics;

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 /// ## Using [`AtomicU64`] as storage and [`u64`] on the interface
 ///
 /// ```
-/// # use open_metrics_client::metrics::counter::Counter;
+/// # use prometheus_client::metrics::counter::Counter;
 /// let counter: Counter = Counter::default();
 /// counter.inc();
 /// let _value: u64 = counter.get();
@@ -30,7 +30,7 @@ use std::sync::Arc;
 /// ## Using [`AtomicU64`] as storage and [`f64`] on the interface
 ///
 /// ```
-/// # use open_metrics_client::metrics::counter::Counter;
+/// # use prometheus_client::metrics::counter::Counter;
 /// # use std::sync::atomic::AtomicU64;
 /// let counter = Counter::<f64, AtomicU64>::default();
 /// counter.inc();

--- a/src/metrics/exemplar.rs
+++ b/src/metrics/exemplar.rs
@@ -21,7 +21,7 @@ pub struct Exemplar<S, V> {
 /// events and track references to data outside of the metric set.
 ///
 /// ```
-/// # use open_metrics_client::metrics::exemplar::CounterWithExemplar;
+/// # use prometheus_client::metrics::exemplar::CounterWithExemplar;
 /// let counter_with_exemplar = CounterWithExemplar::<Vec<(String, String)>>::default();
 /// counter_with_exemplar.inc_by(1, Some(vec![("user_id".to_string(), "42".to_string())]));
 /// let _value: (u64, _) = counter_with_exemplar.get();
@@ -104,8 +104,8 @@ type RwLockGuardedCounterWithExemplar<'a, S, N, A> =
 /// and track references to data outside of the metric set.
 ///
 /// ```
-/// # use open_metrics_client::metrics::exemplar::HistogramWithExemplars;
-/// # use open_metrics_client::metrics::histogram::exponential_buckets;
+/// # use prometheus_client::metrics::exemplar::HistogramWithExemplars;
+/// # use prometheus_client::metrics::histogram::exponential_buckets;
 /// let histogram = HistogramWithExemplars::new(exponential_buckets(1.0, 2.0, 10));
 /// histogram.observe(4.2, Some(vec![("user_id".to_string(), "42".to_string())]));
 /// ```

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -24,10 +24,10 @@ use std::sync::{Arc, RwLock, RwLockReadGuard};
 /// ### [`Family`] with `Vec<(String, String)>` for convenience
 ///
 /// ```
-/// # use open_metrics_client::encoding::text::encode;
-/// # use open_metrics_client::metrics::counter::{Atomic, Counter};
-/// # use open_metrics_client::metrics::family::Family;
-/// # use open_metrics_client::registry::{Descriptor, Registry};
+/// # use prometheus_client::encoding::text::encode;
+/// # use prometheus_client::metrics::counter::{Atomic, Counter};
+/// # use prometheus_client::metrics::family::Family;
+/// # use prometheus_client::registry::{Descriptor, Registry};
 /// #
 /// # let mut registry = Registry::default();
 /// let family = Family::<Vec<(String, String)>, Counter>::default();
@@ -57,11 +57,11 @@ use std::sync::{Arc, RwLock, RwLockReadGuard};
 /// [`Encode`](crate::encoding::text::Encode) implementation.
 ///
 /// ```
-/// # use open_metrics_client::encoding::text::Encode;
-/// # use open_metrics_client::encoding::text::encode;
-/// # use open_metrics_client::metrics::counter::{Atomic, Counter};
-/// # use open_metrics_client::metrics::family::Family;
-/// # use open_metrics_client::registry::{Descriptor, Registry};
+/// # use prometheus_client::encoding::text::Encode;
+/// # use prometheus_client::encoding::text::encode;
+/// # use prometheus_client::metrics::counter::{Atomic, Counter};
+/// # use prometheus_client::metrics::family::Family;
+/// # use prometheus_client::registry::{Descriptor, Registry};
 /// # use std::io::Write;
 /// #
 /// # let mut registry = Registry::default();
@@ -118,8 +118,8 @@ pub struct Family<S, M, C = fn() -> M> {
 /// capture variables.
 ///
 /// ```
-/// # use open_metrics_client::metrics::family::{Family, MetricConstructor};
-/// # use open_metrics_client::metrics::histogram::Histogram;
+/// # use prometheus_client::metrics::family::{Family, MetricConstructor};
+/// # use prometheus_client::metrics::histogram::Histogram;
 /// struct CustomBuilder {
 ///     buckets: Vec<f64>,
 /// }
@@ -142,8 +142,8 @@ pub trait MetricConstructor<M> {
 /// posible to directly provide a closure even if it captures variables.
 ///
 /// ```
-/// # use open_metrics_client::metrics::family::{Family};
-/// # use open_metrics_client::metrics::histogram::Histogram;
+/// # use prometheus_client::metrics::family::{Family};
+/// # use prometheus_client::metrics::histogram::Histogram;
 /// let custom_buckets = vec![0.0, 10.0, 100.0];
 /// let metric = Family::<(), Histogram, _>::new_with_constructor(|| {
 ///     Histogram::new(custom_buckets.clone().into_iter())
@@ -181,8 +181,8 @@ impl<S: Clone + std::hash::Hash + Eq, M, C> Family<S, M, C> {
     /// involved constructors see [`MetricConstructor`].
     ///
     /// ```
-    /// # use open_metrics_client::metrics::family::Family;
-    /// # use open_metrics_client::metrics::histogram::{exponential_buckets, Histogram};
+    /// # use prometheus_client::metrics::family::Family;
+    /// # use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
     /// Family::<Vec<(String, String)>, Histogram>::new_with_constructor(|| {
     ///     Histogram::new(exponential_buckets(1.0, 2.0, 10))
     /// });
@@ -200,8 +200,8 @@ impl<S: Clone + std::hash::Hash + Eq, M, C: MetricConstructor<M>> Family<S, M, C
     /// yet exist.
     ///
     /// ```
-    /// # use open_metrics_client::metrics::counter::{Atomic, Counter};
-    /// # use open_metrics_client::metrics::family::Family;
+    /// # use prometheus_client::metrics::counter::{Atomic, Counter};
+    /// # use prometheus_client::metrics::family::Family;
     /// #
     /// let family = Family::<Vec<(String, String)>, Counter>::default();
     ///

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 /// ## Using [`AtomicU64`] as storage and [`u64`] on the interface
 ///
 /// ```
-/// # use open_metrics_client::metrics::gauge::Gauge;
+/// # use prometheus_client::metrics::gauge::Gauge;
 /// let gauge: Gauge = Gauge::default();
 /// gauge.set(42u64);
 /// let _value: u64 = gauge.get();
@@ -30,7 +30,7 @@ use std::sync::Arc;
 /// ## Using [`AtomicU64`] as storage and [`f64`] on the interface
 ///
 /// ```
-/// # use open_metrics_client::metrics::gauge::Gauge;
+/// # use prometheus_client::metrics::gauge::Gauge;
 /// # use std::sync::atomic::AtomicU64;
 /// let gauge = Gauge::<f64, AtomicU64>::default();
 /// gauge.set(42.0);

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// Open Metrics [`Histogram`] to measure distributions of discrete events.
 ///
 /// ```
-/// # use open_metrics_client::metrics::histogram::{Histogram, exponential_buckets};
+/// # use prometheus_client::metrics::histogram::{Histogram, exponential_buckets};
 /// let histogram = Histogram::new(exponential_buckets(1.0, 2.0, 10));
 /// histogram.observe(4.2);
 /// ```

--- a/src/metrics/info.rs
+++ b/src/metrics/info.rs
@@ -8,7 +8,7 @@ use crate::metrics::{MetricType, TypedMetric};
 /// change during process lifetime".
 ///
 /// ```
-/// # use open_metrics_client::metrics::info::Info;
+/// # use prometheus_client::metrics::info::Info;
 ///
 /// let _info = Info::new(vec![("os", "GNU/linux")]);
 /// ```

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -20,10 +20,10 @@ use std::ops::Add;
 /// users might want to use their custom types.
 ///
 /// ```
-/// # use open_metrics_client::encoding::text::{encode, EncodeMetric};
-/// # use open_metrics_client::metrics::counter::{Atomic as _, Counter};
-/// # use open_metrics_client::metrics::gauge::{Atomic as _, Gauge};
-/// # use open_metrics_client::registry::Registry;
+/// # use prometheus_client::encoding::text::{encode, EncodeMetric};
+/// # use prometheus_client::metrics::counter::{Atomic as _, Counter};
+/// # use prometheus_client::metrics::gauge::{Atomic as _, Gauge};
+/// # use prometheus_client::registry::Registry;
 /// #
 /// // Create a metric registry.
 /// //
@@ -92,8 +92,8 @@ impl<M> Registry<M> {
     /// metric is known.
     ///
     /// ```
-    /// # use open_metrics_client::metrics::counter::{Atomic as _, Counter};
-    /// # use open_metrics_client::registry::{Registry, Unit};
+    /// # use prometheus_client::metrics::counter::{Atomic as _, Counter};
+    /// # use prometheus_client::registry::{Registry, Unit};
     /// #
     /// let mut registry: Registry<Counter> = Registry::default();
     /// let counter = Counter::default();
@@ -113,8 +113,8 @@ impl<M> Registry<M> {
     /// unit to the name manually.
     ///
     /// ```
-    /// # use open_metrics_client::metrics::counter::{Atomic as _, Counter};
-    /// # use open_metrics_client::registry::{Registry, Unit};
+    /// # use prometheus_client::metrics::counter::{Atomic as _, Counter};
+    /// # use prometheus_client::registry::{Registry, Unit};
     /// #
     /// let mut registry: Registry<Counter> = Registry::default();
     /// let counter = Counter::default();
@@ -172,8 +172,8 @@ impl<M> Registry<M> {
     /// subsystem registers.
     ///
     /// ```
-    /// # use open_metrics_client::metrics::counter::{Atomic as _, Counter};
-    /// # use open_metrics_client::registry::{Registry, Unit};
+    /// # use prometheus_client::metrics::counter::{Atomic as _, Counter};
+    /// # use prometheus_client::registry::{Registry, Unit};
     /// #
     /// let mut registry: Registry<Counter> = Registry::default();
     ///


### PR DESCRIPTION
- Move repository from
  https://github.com/mxinden/rust-open-metrics-client to
  https://github.com/prometheus/client_rust.

- Rename crate from `open-metrics-client` to `prometheus-client`.

- Rename import paths from `open_metrics_client` to `prometheus_client`.

See https://groups.google.com/g/prometheus-developers/c/E67ByGmVQKM for
details.

Signed-off-by: Max Inden <mail@max-inden.de>