### PR TITLE
*: Add support for MIPS and PowerPC, which lack support for Atomic{U,I}64

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,6 +144,7 @@ jobs:
       matrix:
         target:
           - armv7-unknown-linux-gnueabihf
+          - mipsel-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/prometheus-client"
 members = ["derive-text-encode"]
 
 [dependencies]
+atomic-shim = "0.2"
 dtoa = "1.0"
 itoa = "1.0"
 owning_ref = "0.4"

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -3,8 +3,9 @@
 //! See [`Counter`] for details.
 
 use super::{MetricType, TypedMetric};
+use atomic_shim::AtomicU64;
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 /// Open Metrics [`Counter`] to measure discrete events.

--- a/src/metrics/exemplar.rs
+++ b/src/metrics/exemplar.rs
@@ -4,9 +4,9 @@
 
 use super::counter::{self, Counter};
 use super::histogram::Histogram;
+use atomic_shim::AtomicU64;
 use owning_ref::OwningRef;
 use std::collections::HashMap;
-use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 pub struct Exemplar<S, V> {

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -3,8 +3,9 @@
 //! See [`Gauge`] for details.
 
 use super::{MetricType, TypedMetric};
+use atomic_shim::AtomicU64;
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 /// Open Metrics [`Gauge`] to record current measurements.


### PR DESCRIPTION
Signed-off-by: Chitoku <odango@chitoku.jp>

---
According to the official documentation, Rust does not provide `std::sync::atomic::AtomicU64` and `std::sync::atomic::AtomicI64` for MIPS and PowerPC with 32-bit pointers.

> PowerPC and MIPS platforms with 32-bit pointers do not have AtomicU64 or AtomicI64 types.

See: https://doc.rust-lang.org/std/sync/atomic/

This means that prometheus-client even doesn't compile for those platforms:

```
[lychee  client_rust | master  $] cross build --release --target=mipsel-unknown-linux-gnu
   Compiling prometheus-client v0.15.0 (/project)
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> src/metrics/counter.rs:7:36
  |
7 | use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
  |                                    ^^^^^^^^^
  |                                    |
  |                                    no `AtomicU64` in `sync::atomic`
  |                                    help: a similar name exists in the module: `AtomicU8`

error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> src/metrics/exemplar.rs:9:5
  |
9 | use std::sync::atomic::AtomicU64;
  |     ^^^^^^^^^^^^^^^^^^^---------
  |     |                  |
  |     |                  help: a similar name exists in the module: `AtomicU8`
  |     no `AtomicU64` in `sync::atomic`

error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> src/metrics/gauge.rs:7:36
  |
7 | use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
  |                                    ^^^^^^^^^
  |                                    |
  |                                    no `AtomicU64` in `sync::atomic`
  |                                    help: a similar name exists in the module: `AtomicU8`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `prometheus-client` due to 3 previous errors
```

The `atomic-shim` crate provides alternative implementation for those platforms if the build target is MIPS or PowerPC, otherwise just re-exports `std::sync::atomic::AtomicU64` and `std::sync::atomic::AtomicI64`. With this patch it successfully compiles. 

```
[lychee  client_rust | support-mips-and-powerpc  $] cross build --release --target=mipsel-unknown-linux-gnu                                                   
    Updating crates.io index                                           
  Downloaded syn v1.0.86                                               
  Downloaded crossbeam-utils v0.8.6                                                                                                            
  Downloaded atomic-shim v0.2.0                                        
  Downloaded 3 crates (284.2 KB) in 0.90s                                                                                                      
   Compiling proc-macro2 v1.0.36                                                                                                               
   Compiling unicode-xid v0.2.2                                                                                                                
   Compiling crossbeam-utils v0.8.6                                    
   Compiling syn v1.0.86                                                                                                                       
   Compiling cfg-if v1.0.0                                             
   Compiling lazy_static v1.4.0                                        
   Compiling stable_deref_trait v1.2.0                                                                                                         
   Compiling itoa v1.0.1                                                                                                                       
   Compiling dtoa v1.0.2                                                                                                                       
   Compiling owning_ref v0.4.1                                                                                                                 
   Compiling atomic-shim v0.2.0                                                                                                                
   Compiling quote v1.0.14                                             
   Compiling prometheus-client-derive-text-encode v0.2.0 (/project/derive-text-encode)                                                         
   Compiling prometheus-client v0.15.0 (/project)                                                                                              
    Finished release [optimized] target(s) in 7.88s
```