### PR TITLE
src/encoding/text.rs: Expose Encoder methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - [unreleased]
+
+### Added
+
+- Expose `Encoder` methods.
+
 ## [0.15.0] - 2022-01-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose `Encoder` methods.
+- Expose `Encoder` methods. See [PR 41].
+
+[PR 41]: https://github.com/prometheus/client_rust/pull/41
 
 ## [0.15.0] - 2022-01-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ async-std = { version = "1", features = ["attributes"] }
 criterion = "0.3"
 http-types = "2"
 pyo3 = "0.15"
-tide = "0.16"
 quickcheck = "1"
+rand = "0.8.4"
+tide = "0.16"
 
 [[bench]]
 name = "family"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2018"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/examples/custom-metric.rs
+++ b/examples/custom-metric.rs
@@ -1,0 +1,52 @@
+use prometheus_client::encoding::text::{encode, EncodeMetric, Encoder};
+use prometheus_client::metrics::MetricType;
+use prometheus_client::registry::Registry;
+
+/// Showcasing encoding of custom metrics.
+///
+/// Related to the concept of "Custom Collectors" in other implementations.
+///
+/// [`MyCustomMetric`] generates and encodes a random number on each scrape.
+struct MyCustomMetric {}
+
+impl EncodeMetric for MyCustomMetric {
+    fn encode(&self, mut encoder: Encoder) -> Result<(), std::io::Error> {
+        // This method is called on each Prometheus server scrape. Allowing you
+        // to execute whatever logic is needed to generate and encode your
+        // custom metric.
+        //
+        // While the `Encoder`'s builder pattern should guide you well and makes
+        // many mistakes impossible at the type level, do keep in mind that
+        // "with great power comes great responsibility". E.g. every CPU cycle
+        // spend in this method delays the response send to the Prometheus
+        // server.
+
+        encoder
+            .no_suffix()?
+            .no_bucket()?
+            .encode_value(rand::random::<u32>())?
+            .no_exemplar()?;
+
+        Ok(())
+    }
+
+    fn metric_type(&self) -> prometheus_client::metrics::MetricType {
+        MetricType::Unknown
+    }
+}
+
+fn main() {
+    let mut registry = Registry::default();
+
+    let metric = MyCustomMetric {};
+    registry.register(
+        "my_custom_metric",
+        "Custom metric returning a random number on each scrape",
+        metric,
+    );
+
+    let mut encoded = Vec::new();
+    encode(&mut encoded, &registry).unwrap();
+
+    println!("Scrape output:\n{:?}", String::from_utf8(encoded).unwrap());
+}


### PR DESCRIPTION
By exposing the various `Encoder` builder methods, downstream users can
implement their custom metrics using `EncodeMetric`.

See https://github.com/prometheus/client_rust/issues/36 for additional context.

//CC @phyber