### PR TITLE
*: Remove AtomicU64 on unsupported platforms

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -145,6 +145,7 @@ jobs:
         target:
           - armv7-unknown-linux-gnueabihf
           - mipsel-unknown-linux-gnu
+          - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,6 +144,7 @@ jobs:
       matrix:
         target:
           - armv7-unknown-linux-gnueabihf
+          - mipsel-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expose `Encoder` methods. See [PR 41].
 
+### Changed
+
+- Use `AtomicU32` on platforms that don't support `AtomicU64`. See [PR 42].
+
 [PR 41]: https://github.com/prometheus/client_rust/pull/41
+[PR 42]: https://github.com/prometheus/client_rust/pull/42
 
 ## [0.15.0] - 2022-01-16
 

--- a/src/metrics/exemplar.rs
+++ b/src/metrics/exemplar.rs
@@ -6,6 +6,9 @@ use super::counter::{self, Counter};
 use super::histogram::Histogram;
 use owning_ref::OwningRef;
 use std::collections::HashMap;
+#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+use std::sync::atomic::AtomicU32;
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 
@@ -26,7 +29,13 @@ pub struct Exemplar<S, V> {
 /// counter_with_exemplar.inc_by(1, Some(vec![("user_id".to_string(), "42".to_string())]));
 /// let _value: (u64, _) = counter_with_exemplar.get();
 /// ```
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
 pub struct CounterWithExemplar<S, N = u64, A = AtomicU64> {
+    pub(crate) inner: Arc<RwLock<CounterWithExemplarInner<S, N, A>>>,
+}
+
+#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+pub struct CounterWithExemplar<S, N = u32, A = AtomicU32> {
     pub(crate) inner: Arc<RwLock<CounterWithExemplarInner<S, N, A>>>,
 }
 

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -4,7 +4,9 @@
 
 use super::{MetricType, TypedMetric};
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 /// Open Metrics [`Gauge`] to record current measurements.
@@ -36,7 +38,14 @@ use std::sync::Arc;
 /// gauge.set(42.0);
 /// let _value: f64 = gauge.get();
 /// ```
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
 pub struct Gauge<N = u64, A = AtomicU64> {
+    value: Arc<A>,
+    phantom: PhantomData<N>,
+}
+
+#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+pub struct Gauge<N = u32, A = AtomicU32> {
     value: Arc<A>,
     phantom: PhantomData<N>,
 }
@@ -113,6 +122,7 @@ pub trait Atomic<N> {
     fn get(&self) -> N;
 }
 
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
 impl Atomic<u64> for AtomicU64 {
     fn inc(&self) -> u64 {
         self.inc_by(1)
@@ -165,6 +175,7 @@ impl Atomic<u32> for AtomicU32 {
     }
 }
 
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
 impl Atomic<f64> for AtomicU64 {
     fn inc(&self) -> f64 {
         self.inc_by(1.0)


### PR DESCRIPTION
As stated in #37 in regard to how this crate handles `std::sync::atomic::AtomicU64`, this PR removes any occurrences of this struct and instead defaults to its 32-bit version where appropriate.

```
[lychee  client_rust | drop-atomic64-for-unsupported-platforms  $] cross build --release --target=mipsel-unknown-linux-gnu
    Finished release [optimized] target(s) in 0.09s
```