### PR TITLE
Replace `SendEncodeMetric` with `SendSyncEncodeMetric`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - unreleased
+
+### Changed
+
+- Require `Registry` default generic type `SendEncodeMetric` to be `Sync`. See [PR 58].
+
+[PR 58]: https://github.com/prometheus/client_rust/pull/58
+
 ## [0.15.1] - 2022-02-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2018"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -404,11 +404,11 @@ impl EncodeMetric for Box<dyn EncodeMetric> {
     }
 }
 
-pub trait SendEncodeMetric: EncodeMetric + Send {}
+pub trait SendSyncEncodeMetric: EncodeMetric + Send + Sync {}
 
-impl<T: EncodeMetric + Send> SendEncodeMetric for T {}
+impl<T: EncodeMetric + Send + Sync> SendSyncEncodeMetric for T {}
 
-impl EncodeMetric for Box<dyn SendEncodeMetric> {
+impl EncodeMetric for Box<dyn SendSyncEncodeMetric> {
     fn encode(&self, encoder: Encoder) -> Result<(), std::io::Error> {
         self.deref().encode(encoder)
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -58,7 +58,7 @@ use std::ops::Add;
 /// #                "# EOF\n";
 /// # assert_eq!(expected, String::from_utf8(buffer).unwrap());
 /// ```
-pub struct Registry<M = Box<dyn crate::encoding::text::SendEncodeMetric>> {
+pub struct Registry<M = Box<dyn crate::encoding::text::SendSyncEncodeMetric>> {
     prefix: Option<Prefix>,
     labels: Vec<(Cow<'static, str>, Cow<'static, str>)>,
     metrics: Vec<(Descriptor, M)>,


### PR DESCRIPTION
This will allow the default `Registry` to be used in multi-threaded
environments (e.g. web servers) where the registry needs to be shared
between threads.

Closes #57.
