### PR TITLE
src/registry.rs: Remove Add trait impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove Add trait implementation for a private type. See [PR 69].
+- Remove `Add` trait implementation for a private type which lead to compile time conflicts with existing `Add` implementations e.g. on `String`. See [PR 69].
 
 [PR 65]: https://github.com/prometheus/client_rust/pull/65
 [PR 69]: https://github.com/prometheus/client_rust/pull/69

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updates to Rust 2021 Edition. See [PR 65].
 
+### Removed
+
+- Remove Add trait implementation for a private type. See [PR 69].
+
 [PR 65]: https://github.com/prometheus/client_rust/pull/65
+[PR 69]: https://github.com/prometheus/client_rust/pull/69
 
 ## [0.16.0]
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3,7 +3,6 @@
 //! See [`Registry`] for details.
 
 use std::borrow::Cow;
-use std::ops::Add;
 
 /// A metric registry.
 ///
@@ -149,7 +148,7 @@ impl<M> Registry<M> {
             name: self
                 .prefix
                 .as_ref()
-                .map(|p| (p.clone() + "_" + name.as_str()).into())
+                .map(|p| (p.clone().0 + "_" + name.as_str()))
                 .unwrap_or(name),
             help,
             unit,
@@ -196,13 +195,9 @@ impl<M> Registry<M> {
     /// but namespacing with a label instead of a metric name prefix.
     pub fn sub_registry_with_prefix<P: AsRef<str>>(&mut self, prefix: P) -> &mut Self {
         let sub_registry = Registry {
-            prefix: Some(
-                self.prefix
-                    .clone()
-                    .map(|p| p + "_")
-                    .unwrap_or_else(|| String::new().into())
-                    + prefix.as_ref(),
-            ),
+            prefix: Some(Prefix(
+                self.prefix.clone().map(|p| p.0 + "_").unwrap_or_default() + prefix.as_ref(),
+            )),
             labels: self.labels.clone(),
             ..Default::default()
         };
@@ -289,20 +284,6 @@ impl From<String> for Prefix {
 impl From<Prefix> for String {
     fn from(p: Prefix) -> Self {
         p.0
-    }
-}
-
-impl Add<&str> for Prefix {
-    type Output = Self;
-    fn add(self, rhs: &str) -> Self::Output {
-        Prefix(self.0 + rhs)
-    }
-}
-
-impl Add<&Prefix> for String {
-    type Output = Self;
-    fn add(self, rhs: &Prefix) -> Self::Output {
-        self + rhs.0.as_str()
     }
 }
 


### PR DESCRIPTION
They interact with builtin implementation in confusing ways:
https://github.com/rust-lang/rust/issues/77143

Fixes https://github.com/prometheus/client_rust/issues/68
