### PR TITLE
Add with_prefix to Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates to Rust 2021 Edition. See [PR 65].
 
 ### Added
-- Added a `with_prefix` method to `Registry` to allow initializing a registry with a prefix. See [PR 70]
+- Added a `with_prefix` method to `Registry` to allow initializing a registry with a prefix. See [PR 70].
 
 ### Removed
 - Remove `Add` trait implementation for a private type which lead to compile time conflicts with existing `Add` implementations e.g. on `String`. See [PR 69].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.0] - unreleased
 
 ### Changed
-
 - Updates to Rust 2021 Edition. See [PR 65].
 
-### Removed
+### Added
+- Added a `with_prefix` method to `Registry` to allow initializing a registry with a prefix. See [PR 70]
 
+### Removed
 - Remove `Add` trait implementation for a private type which lead to compile time conflicts with existing `Add` implementations e.g. on `String`. See [PR 69].
 
 [PR 65]: https://github.com/prometheus/client_rust/pull/65
 [PR 69]: https://github.com/prometheus/client_rust/pull/69
+[PR 70]: https://github.com/prometheus/client_rust/pull/70
 
 ## [0.16.0]
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -76,7 +76,7 @@ impl<M> Default for Registry<M> {
 }
 
 impl<M> Registry<M> {
-    /// Creates a new default registry with the given prefix.
+    /// Creates a new default [`Registry`] with the given prefix.
     pub fn with_prefix(prefix: impl Into<String>) -> Self {
         Self {
             prefix: Some(Prefix(prefix.into())),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -76,6 +76,14 @@ impl<M> Default for Registry<M> {
 }
 
 impl<M> Registry<M> {
+    /// Creates a new default registry with the given prefix.
+    pub fn with_prefix(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: Some(Prefix(prefix.into())),
+            ..Default::default()
+        }
+    }
+
     /// Register a metric with the [`Registry`].
     ///
     /// Note: In the Open Metrics text exposition format some metric types have


### PR DESCRIPTION
Adds the ability to create a registry with a prefix.

This is actually already possible through the below hack but this makes it a lot easier and neater.

```rust
let prefixed_registry = {
    let mut registry = <Registry>::default();
    let prefixed_registry = registry.sub_registry_with_prefix(prefix);
    std::mem::take(prefixed_registry)
};
```

This is useful to set an application-wide prefix on the single registry for all your metrics.