### PR TITLE
Collector pattern

### DIFF
--- a/examples/tide.rs
+++ b/examples/tide.rs
@@ -31,7 +31,7 @@ async fn main() -> std::result::Result<(), std::io::Error> {
     app.at("/metrics")
         .get(|req: tide::Request<State>| async move {
             let mut encoded = Vec::new();
-            encode(&mut encoded, &req.state().registry).unwrap();
+            encode(&mut encoded, req.state().registry.as_ref()).unwrap();
             let response = tide::Response::builder(200)
                 .body(encoded)
                 .content_type("application/openmetrics-text; version=1.0.0; charset=utf-8")

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -262,7 +262,7 @@ where
 
 impl<'a, M> Collector<'a, M> for Registry<M>
 where
-    M: SendSyncEncodeMetric + 'a,
+    M: EncodeMetric + 'a,
 {
     fn collect(&'a self) -> Vec<&'a (Descriptor, M)> {
         self.iter().collect()
@@ -271,7 +271,7 @@ where
 
 impl<'a, M, C> Collector<'a, M> for Vec<&'a C>
 where
-    M: SendSyncEncodeMetric + 'a,
+    M: EncodeMetric + 'a,
     C: Collector<'a, M>,
 {
     fn collect(&'a self) -> Vec<&'a (Descriptor, M)> {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -269,14 +269,13 @@ where
     }
 }
 
-impl<'a, M> Collector<'a, M> for Vec<&'a Registry<M>>
+impl<'a, M, C> Collector<'a, M> for Vec<&'a C>
 where
     M: SendSyncEncodeMetric + 'a,
+    C: Collector<'a, M>,
 {
     fn collect(&'a self) -> Vec<&'a (Descriptor, M)> {
-        self.iter()
-            .flat_map(|r| r.iter().collect::<Vec<&'a (Descriptor, M)>>())
-            .collect()
+        self.iter().flat_map(|r| r.collect()).collect()
     }
 }
 


### PR DESCRIPTION
This is an implementation of a `Collector` trait for collecting all the Metric Families from one or more Registries to encode them all at once.

For example, this allows exporting metrics by combining a "long-running" `Registry` with a per-scrape `Registry`.

This is in response to #29, #49 and #73.

Implementation is rather crude, but the out-facing interface is basically unchaged.