### PR TITLE
*: Move to `parking_lot` and thus make `owning_ref` obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - unreleased
+
+### Changed
+
+- Use `parking_lot` instead of `std::sync::*`.
+
+  Before `proemtheus-client` would use the `owning_ref` crate to map the target
+  of a `std::sync::RwLockReadGuard`. `owning_ref` has multiple unsoundness
+  issues, see https://rustsec.org/advisories/RUSTSEC-2022-0040.html. Instead of
+  replacing `owning_ref` with a similar crate, we switch to locking via
+  `parking_lot` which supports the above mapping natively.
+
 ## [0.17.0]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."
@@ -16,7 +16,7 @@ members = ["derive-text-encode"]
 [dependencies]
 dtoa = "1.0"
 itoa = "1.0"
-owning_ref = "0.4"
+parking_lot = "0.12"
 prometheus-client-derive-text-encode = { version = "0.3.0", path = "derive-text-encode" }
 
 [dev-dependencies]

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -449,7 +449,7 @@ where
 {
     fn encode(&self, encoder: Encoder) -> Result<(), std::io::Error> {
         let (value, exemplar) = self.get();
-        encode_counter_with_maybe_exemplar(value, exemplar.as_ref().as_ref(), encoder)
+        encode_counter_with_maybe_exemplar(value, exemplar.as_ref(), encoder)
     }
 
     fn metric_type(&self) -> MetricType {


### PR DESCRIPTION
Before `proemtheus-client` would use the `owning_ref` crate to map the target
of a `std::sync::RwLockReadGuard`. `owning_ref` has multiple unsoundness
issues, see https://rustsec.org/advisories/RUSTSEC-2022-0040.html. Instead of
replacing `owning_ref` with a similar crate, we switch to locking via
`parking_lot` which supports the above mapping natively.

Fixes https://github.com/prometheus/client_rust/issues/77