### PR TITLE
derive-encode: Fix `multiple applicable items in scope` error

### DIFF
--- a/derive-encode/src/lib.rs
+++ b/derive-encode/src/lib.rs
@@ -104,7 +104,7 @@ fn derive_protobuf_encode(ast: DeriveInput) -> TokenStream2 {
                         quote! {
                             let mut label = {
                                 let mut labels = vec![];
-                                self.#ident.encode(&mut labels);
+                                prometheus_client::encoding::proto::EncodeLabels::encode(&self.#ident, &mut labels);
                                 debug_assert_eq!(1, labels.len(), "Labels encoded from {} should have only one label.", #ident_string);
                                 labels.pop().expect("should have an element")
                             };

--- a/derive-encode/tests/lib.rs
+++ b/derive-encode/tests/lib.rs
@@ -99,51 +99,6 @@ mod protobuf {
         assert_eq!("Method", label.name);
         assert_eq!("Get", label.value);
     }
-
-    mod multiple_applicable_items_in_scope {
-        use prometheus_client::encoding::proto::encode;
-        use prometheus_client::encoding::Encode;
-        use prometheus_client::metrics::counter::Counter;
-        use prometheus_client::metrics::family::Family;
-        use prometheus_client::registry::Registry;
-
-        // This is a trait to reproduce `multiple applicable items in scope` error.
-        //
-        // error[E0034]: multiple applicable items in scope
-        //    --> derive-encode/tests/lib.rs:120:46
-        //     |
-        // 120 |         #[derive(Clone, Hash, PartialEq, Eq, Encode)]
-        //     |                                              ^^^^^^ multiple `encode` found
-        trait Test {
-            fn encode(&self);
-        }
-
-        impl Test for String {
-            fn encode(&self) {
-                println!("TEST");
-            }
-        }
-
-        #[derive(Clone, Hash, PartialEq, Eq, Encode)]
-        struct Labels {
-            path: String,
-        }
-
-        #[test]
-        fn test() {
-            let mut registry = Registry::default();
-            let family = Family::<Labels, Counter>::default();
-            registry.register("my_counter", "This is my counter", family.clone());
-
-            family
-                .get_or_create(&Labels {
-                    path: "/metrics".to_string(),
-                })
-                .inc();
-
-            let _ = encode(&registry);
-        }
-    }
 }
 
 #[test]

--- a/derive-encode/tests/lib.rs
+++ b/derive-encode/tests/lib.rs
@@ -99,6 +99,51 @@ mod protobuf {
         assert_eq!("Method", label.name);
         assert_eq!("Get", label.value);
     }
+
+    mod multiple_applicable_items_in_scope {
+        use prometheus_client::encoding::proto::encode;
+        use prometheus_client::encoding::Encode;
+        use prometheus_client::metrics::counter::Counter;
+        use prometheus_client::metrics::family::Family;
+        use prometheus_client::registry::Registry;
+
+        // This is a trait to reproduce `multiple applicable items in scope` error.
+        //
+        // error[E0034]: multiple applicable items in scope
+        //    --> derive-encode/tests/lib.rs:120:46
+        //     |
+        // 120 |         #[derive(Clone, Hash, PartialEq, Eq, Encode)]
+        //     |                                              ^^^^^^ multiple `encode` found
+        trait Test {
+            fn encode(&self);
+        }
+
+        impl Test for String {
+            fn encode(&self) {
+                println!("TEST");
+            }
+        }
+
+        #[derive(Clone, Hash, PartialEq, Eq, Encode)]
+        struct Labels {
+            path: String,
+        }
+
+        #[test]
+        fn test() {
+            let mut registry = Registry::default();
+            let family = Family::<Labels, Counter>::default();
+            registry.register("my_counter", "This is my counter", family.clone());
+
+            family
+                .get_or_create(&Labels {
+                    path: "/metrics".to_string(),
+                })
+                .inc();
+
+            let _ = encode(&registry);
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
`multiple applicable items in scope` error happens when there is an `encode` implementation (e.g. [`prost::Message`](https://docs.rs/prost/latest/prost/trait.Message.html)) in the same scope.

```shell
        // error[E0034]: multiple applicable items in scope
        //     |
        // 120 |         #[derive(Clone, Hash, PartialEq, Eq, Encode)]
        //     |                                              ^^^^^^ multiple `encode` found
```