### PR TITLE
Example metrics server using Hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ quickcheck = "1"
 rand = "0.8.4"
 tide = "0.16"
 actix-web = "4"
+tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal"] }
+hyper = { version = "0.14.16", features = ["server", "http1", "tcp"] }
 
 [build-dependencies]
 prost-build = { version = "0.9.0", optional = true }

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -1,0 +1,75 @@
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use prometheus_client::{encoding::text::encode, metrics::counter::Counter, registry::Registry};
+use std::{
+    future::Future,
+    io,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+};
+use tokio::signal::unix::{signal, SignalKind};
+
+#[tokio::main]
+async fn main() {
+    let request_counter: Counter<u64> = Default::default();
+
+    let mut registry = <Registry>::with_prefix("tokio_hyper_example");
+
+    registry.register(
+        "requests",
+        "How many requests the application has received",
+        Box::new(request_counter.clone()),
+    );
+
+    // Spawn a server to serve the OpenMetrics endpoint.
+    let metrics_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8001);
+    start_metrics_server(metrics_addr, registry).await
+}
+
+/// Start a HTTP server to report metrics.
+pub async fn start_metrics_server(metrics_addr: SocketAddr, registry: Registry) {
+    let mut shutdown_stream = signal(SignalKind::terminate()).unwrap();
+
+    eprintln!("Starting metrics server on {metrics_addr}");
+
+    let registry = Arc::new(registry);
+    Server::bind(&metrics_addr)
+        .serve(make_service_fn(move |_conn| {
+            let registry = registry.clone();
+            async move {
+                let handler = make_handler(registry);
+                Ok::<_, io::Error>(service_fn(handler))
+            }
+        }))
+        .with_graceful_shutdown(async move {
+            shutdown_stream.recv().await;
+        })
+        .await
+        .unwrap();
+}
+
+/// This function returns a HTTP handler (i.e. another function)
+pub fn make_handler(
+    registry: Arc<Registry>,
+) -> impl Fn(Request<Body>) -> Pin<Box<dyn Future<Output = io::Result<Response<Body>>> + Send>> {
+    // This closure accepts a request and responds with the OpenMetrics encoding of our metrics.
+    move |_req: Request<Body>| {
+        let reg = registry.clone();
+        Box::pin(async move {
+            let mut buf = Vec::new();
+            encode(&mut buf, &reg.clone()).map(|_| {
+                let body = Body::from(buf);
+                Response::builder()
+                    .header(
+                        hyper::header::CONTENT_TYPE,
+                        "application/openmetrics-text; version=1.0.0; charset=utf-8",
+                    )
+                    .body(body)
+                    .unwrap()
+            })
+        })
+    }
+}


### PR DESCRIPTION
Say your Rust app is not a web server. You probably don't need to pull in a whole web framework like Axum or Actix-web just to serve one little OpenMetrics endpoint. You can just use Hyper instead. Here's an example of how to do that.

I also added this an example target in Cargo.toml, so that you can run it with cargo:

```sh
$ cargo run --example hyper  &
$ curl localhost:8001
# HELP tokio_hyper_example_example_counter An example counter that will get incremented automatically.
# TYPE tokio_hyper_example_example_counter counter
tokio_hyper_example_example_counter_total 6
# EOF
```