### PR TITLE
impl TypedMetric for Counter/HistogramWithExemplars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   set from a family. See [PR 85].
 - Added a `clear` method to `Family` to allow the removal of all label sets
   from a family. See [PR 85].
+- Impl `TypedMetric` for `CounterWithExemplar` and `HistogramWithExemplar`, so that they can be used with `Family`. See [PR 96].
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [PR 83]: https://github.com/prometheus/client_rust/pull/83
 [PR 85]: https://github.com/prometheus/client_rust/pull/85
+[PR 96]: https://github.com/prometheus/client_rust/pull/96
 
 ## [0.18.0]
 


### PR DESCRIPTION
Fixes #95, i.e. that on master, you cannot create a Histogram or Counter which has both a Family and Exemplars. Also adds an example showing how to make such a histogram/counter. This example won't compile without my fix, so it also serves as a regression test :)

Running my example gives the expected output:
```
# HELP latency help text goes here.
# TYPE latency histogram
latency_sum{result="success"} 0.001345422
latency_count{result="success"} 1
latency_bucket{result="success",le="1.0"} 1 # {trace_id="3a2f90c9f80b894f"} 0.001345422
```

If you approve this PR, would you please also consider cutting a release 0.19 for it? I think most real-world exemplars will also want to use families, so I think this feature is worth releasing soon. My team at Cloudflare is gonna use my fork with this PR for now, but I'd like to start using this crate in more projects internally, and we try to avoid relying on Github forks :)

Thanks again for making this library. I've been using the old prometheus crate since 2018, and made a few PRs here and there, so I really appreciate you modernizing it and adding full OpenMetrics compliance.