### PR TITLE
chore: Bump Prost to 0.11

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,8 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -45,6 +47,8 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -79,6 +83,8 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -95,6 +101,8 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -124,6 +132,8 @@ jobs:
     name: Check rustdoc intra-doc links
     runs-on: ubuntu-latest
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -159,4 +169,4 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target=${{ matrix.target }} --all-features
+          args: --release --target=${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -169,4 +169,5 @@ jobs:
         with:
           use-cross: true
           command: build
+          # Note that this does not test the `protobuf` feature (for now). See reasoning in https://github.com/prometheus/client_rust/pull/98/.
           args: --release --target=${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ dtoa = "1.0"
 itoa = "1.0"
 parking_lot = "0.12"
 prometheus-client-derive-encode = { version = "0.3.0", path = "derive-encode" }
-prost = { version = "0.9.0", optional = true }
-prost-types = { version = "0.9.0", optional = true }
+prost = { version = "0.11.0", optional = true }
+prost-types = { version = "0.11.0", optional = true }
 void = { version = "1.0", optional = true }
 
 [dev-dependencies]
@@ -38,7 +38,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal
 hyper = { version = "0.14.16", features = ["server", "http1", "tcp"] }
 
 [build-dependencies]
-prost-build = { version = "0.9.0", optional = true }
+prost-build = { version = "0.11.0", optional = true }
 
 [[bench]]
 name = "family"


### PR DESCRIPTION
I noticed the Dependabot PRs (#89 #90 #92), but you really have to update all three Prost crates simultaneously because otherwise you'll get weird errors between versions. So, here's one PR to bump prost's family of crates.