### PR TITLE
encoding/proto: Add a trait combining EncodeMetric, Send and Sync

### DIFF
--- a/src/encoding/proto.rs
+++ b/src/encoding/proto.rs
@@ -214,6 +214,25 @@ where
     exemplar_proto
 }
 
+/// Trait combining [`EncodeMetric`], [`Send`] and [`Sync`].
+pub trait SendSyncEncodeMetric: EncodeMetric + Send + Sync {}
+
+impl<T: EncodeMetric + Send + Sync> SendSyncEncodeMetric for T {}
+
+impl EncodeMetric for Box<dyn SendSyncEncodeMetric> {
+    fn encode(
+        &self,
+        labels: Vec<openmetrics_data_model::Label>,
+        family: &mut Vec<openmetrics_data_model::Metric>,
+    ) {
+        self.deref().encode(labels, family)
+    }
+
+    fn metric_type(&self) -> MetricType {
+        self.deref().metric_type()
+    }
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 // Counter
 


### PR DESCRIPTION
The same as [encoding::text](https://github.com/prometheus/client_rust/blob/master/src/encoding/text.rs#L406), I added `SendSyncEncodeMetric` trait combining EncodeMetric, Send, and Sync.