### PR TITLE
src/registry: Use dynamic dispatch and remove type parameter M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Always use dynamic dispatch on Registry, i.e. remove generic type parameter `M` from `Registry`.
+
 - Move`Encode` trait from `prometheus_client::encoding::text` to `prometheus_client::encoding`. See [PR 83].
 
 [PR 83]: https://github.com/prometheus/client_rust/pull/83

--- a/examples/actix-web.rs
+++ b/examples/actix-web.rs
@@ -7,13 +7,13 @@ use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::registry::Registry;
 
-#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 pub enum Method {
     Get,
     Post,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 pub struct MethodLabels {
     pub method: Method,
 }
@@ -55,11 +55,9 @@ async fn main() -> std::io::Result<()> {
     let mut state = AppState {
         registry: Registry::default(),
     };
-    state.registry.register(
-        "requests",
-        "Count of requests",
-        Box::new(metrics.requests.clone()),
-    );
+    state
+        .registry
+        .register("requests", "Count of requests", metrics.requests.clone());
     let state = web::Data::new(Mutex::new(state));
 
     HttpServer::new(move || {

--- a/examples/custom-metric.rs
+++ b/examples/custom-metric.rs
@@ -7,6 +7,7 @@ use prometheus_client::registry::Registry;
 /// Related to the concept of "Custom Collectors" in other implementations.
 ///
 /// [`MyCustomMetric`] generates and encodes a random number on each scrape.
+#[derive(Debug)]
 struct MyCustomMetric {}
 
 impl EncodeMetric for MyCustomMetric {

--- a/examples/tide.rs
+++ b/examples/tide.rs
@@ -44,13 +44,13 @@ async fn main() -> std::result::Result<(), std::io::Error> {
     Ok(())
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 struct Labels {
     method: Method,
     path: String,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 enum Method {
     Get,
     Put,
@@ -58,7 +58,7 @@ enum Method {
 
 #[derive(Clone)]
 struct State {
-    registry: Arc<Registry<Family<Labels, Counter>>>,
+    registry: Arc<Registry>,
 }
 
 #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! //
 //! // You could as well use `(String, String)` to represent a label set,
 //! // instead of the custom type below.
-//! #[derive(Clone, Hash, PartialEq, Eq, Encode)]
+//! #[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 //! struct Labels {
 //!   // Use your own enum types to represent label values.
 //!   method: Method,
@@ -38,7 +38,7 @@
 //!   path: String,
 //! };
 //!
-//! #[derive(Clone, Hash, PartialEq, Eq, Encode)]
+//! #[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 //! enum Method {
 //!   GET,
 //!   PUT,
@@ -54,7 +54,7 @@
 //!   "http_requests",
 //!   // And the metric help text.
 //!   "Number of HTTP requests received",
-//!   Box::new(http_requests.clone()),
+//!   http_requests.clone(),
 //! );
 //!
 //! // Somewhere in your business logic record a single HTTP GET request.

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -65,12 +65,12 @@ use std::sync::Arc;
 /// # use std::io::Write;
 /// #
 /// # let mut registry = Registry::default();
-/// #[derive(Clone, Hash, PartialEq, Eq, Encode)]
+/// #[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 /// struct Labels {
 ///   method: Method,
 /// };
 ///
-/// #[derive(Clone, Hash, PartialEq, Eq, Encode)]
+/// #[derive(Clone, Debug, Hash, PartialEq, Eq, Encode)]
 /// enum Method {
 ///   GET,
 ///   PUT,
@@ -97,7 +97,6 @@ use std::sync::Arc;
 /// # assert_eq!(expected, String::from_utf8(buffer).unwrap());
 /// ```
 // TODO: Consider exposing hash algorithm.
-#[derive(Debug)]
 pub struct Family<S, M, C = fn() -> M> {
     metrics: Arc<RwLock<HashMap<S, M>>>,
     /// Function that when called constructs a new metric.
@@ -109,6 +108,14 @@ pub struct Family<S, M, C = fn() -> M> {
     /// specific buckets, a custom constructor is set via
     /// [`Family::new_with_constructor`].
     constructor: C,
+}
+
+impl<S: std::fmt::Debug, M: std::fmt::Debug, C> std::fmt::Debug for Family<S, M, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Family")
+            .field("metrics", &self.metrics)
+            .finish()
+    }
 }
 
 /// A constructor for creating new metrics in a [`Family`] when calling


### PR DESCRIPTION
Instead of being generic over the metric type on `Registry`, use dynamic dispatch.

On the upside this significantly simplifies type signatures exposed to the user. On the downside this requires users to always use dynamic dispatch and requires all metrics to implement auxiliary trait `Debug` and auto traits `Send` and `Sync`.

Initially suggested in https://github.com/prometheus/client_rust/pull/82#discussion_r956892586

Would replace https://github.com/prometheus/client_rust/pull/99 //CC @ackintosh @adamchalmers 

Happy for alternative suggestions. //CC @thomaseizinger in case you are interested and have ideas.

