### PR TITLE
*: Prepare v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.18.1] - unreleased
+## [0.18.1]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - unreleased
+
+### Fixed
+
+- Fix race condition in `Family::get_or_create`. See [PR 102].
+
+[PR 102]: https://github.com/prometheus/client_rust/pull/102
+
 ## [0.18.0]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."


### PR DESCRIPTION
Releases https://github.com/prometheus/client_rust/pull/102 as `prometheus-client` `v0.18.1`.

Note that this targets the `release-v0.18` branch and not `master`. Port to `master` is happening in a follow up.

//CC @nox