### PR TITLE
src/encoding: Take reference for value

### DIFF
--- a/examples/custom-metric.rs
+++ b/examples/custom-metric.rs
@@ -20,7 +20,7 @@ impl EncodeMetric for MyCustomMetric {
         // E.g. every CPU cycle spend in this method delays the response send to
         // the Prometheus server.
 
-        encoder.encode_counter::<(), _, u64>(rand::random::<u64>(), None)
+        encoder.encode_counter::<(), _, u64>(&rand::random::<u64>(), None)
     }
 
     fn metric_type(&self) -> prometheus_client::metrics::MetricType {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -96,14 +96,17 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
         ExemplarValue: EncodeExemplarValue,
     >(
         &mut self,
-        v: CounterValue,
+        v: &CounterValue,
         exemplar: Option<&Exemplar<S, ExemplarValue>>,
     ) -> Result<(), std::fmt::Error> {
         for_both_mut!(self, MetricEncoderInner, e, e.encode_counter(v, exemplar))
     }
 
     /// Encode a gauge.
-    pub fn encode_gauge(&mut self, v: impl EncodeGaugeValue) -> Result<(), std::fmt::Error> {
+    pub fn encode_gauge<GaugeValue: EncodeGaugeValue>(
+        &mut self,
+        v: &GaugeValue,
+    ) -> Result<(), std::fmt::Error> {
         for_both_mut!(self, MetricEncoderInner, e, e.encode_gauge(v))
     }
 

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -112,10 +112,14 @@ impl<'a, 'b> std::fmt::Debug for MetricEncoder<'a, 'b> {
 }
 
 impl<'a, 'b> MetricEncoder<'a, 'b> {
-    pub fn encode_counter<S: EncodeLabelSet, V: EncodeExemplarValue>(
+    pub fn encode_counter<
+        S: EncodeLabelSet,
+        CounterValue: super::EncodeCounterValue,
+        ExemplarValue: EncodeExemplarValue,
+    >(
         &mut self,
-        v: impl super::EncodeCounterValue,
-        exemplar: Option<&Exemplar<S, V>>,
+        v: &CounterValue,
+        exemplar: Option<&Exemplar<S, ExemplarValue>>,
     ) -> Result<(), std::fmt::Error> {
         self.write_name_and_unit()?;
 
@@ -139,7 +143,10 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
         Ok(())
     }
 
-    pub fn encode_gauge(&mut self, v: impl super::EncodeGaugeValue) -> Result<(), std::fmt::Error> {
+    pub fn encode_gauge<GaugeValue: super::EncodeGaugeValue>(
+        &mut self,
+        v: &GaugeValue,
+    ) -> Result<(), std::fmt::Error> {
         self.write_name_and_unit()?;
 
         self.encode_labels::<()>(None)?;

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -179,7 +179,7 @@ where
     A: Atomic<N>,
 {
     fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
-        encoder.encode_counter::<(), _, u64>(self.get(), None)
+        encoder.encode_counter::<(), _, u64>(&self.get(), None)
     }
 
     fn metric_type(&self) -> MetricType {

--- a/src/metrics/exemplar.rs
+++ b/src/metrics/exemplar.rs
@@ -157,7 +157,7 @@ where
 {
     fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
         let (value, exemplar) = self.get();
-        encoder.encode_counter(value, exemplar.as_ref())
+        encoder.encode_counter(&value, exemplar.as_ref())
     }
 
     fn metric_type(&self) -> MetricType {

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -246,7 +246,7 @@ where
     A: Atomic<N>,
 {
     fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
-        encoder.encode_gauge(self.get())
+        encoder.encode_gauge(&self.get())
     }
     fn metric_type(&self) -> MetricType {
         Self::TYPE


### PR DESCRIPTION
No need to take ownership of the value. Relevant when using with non-copy types.

Signed-off-by: Max Inden <mail@max-inden.de>