### PR TITLE
feat(derive): Introduce flatten attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `Collector` abstraction allowing users to provide additional metrics
   and their description on each scrape. See [PR 82].
 - Introduce a `#[prometheus(flatten)]` attribute which can be used when deriving `EncodeLabelSet`, allowing
-  a nested struct the be flattened during encoding. See [PR 118].
+  a nested struct to be flattened during encoding. See [PR 118].
+  For example:
+  ```rust
+  #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+  struct CommonLabels {
+      a: u64,
+      b: u64,
+  }
+  #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+  struct Labels {
+      unique: u64,
+      #[prometheus(flatten)]
+      common: CommonLabels,
+  }
+
+  // Would result in `my_metric{a="42",b="42",unique="42"} 42
+  ```
 
 [PR 82]: https://github.com/prometheus/client_rust/pull/82
 [PR 118]: https://github.com/prometheus/client_rust/pull/118

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduce `Collector` abstraction allowing users to provide additional metrics
   and their description on each scrape. See [PR 82].
+- Introduce a `#[prometheus(flatten)]` attribute which can be used when deriving `EncodeLabelSet`, allowing
+  a nested struct the be flattened during encoding. See [PR 118].
 
 [PR 82]: https://github.com/prometheus/client_rust/pull/82
+[PR 118]: https://github.com/prometheus/client_rust/pull/118
 
 ## [0.19.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduce `Collector` abstraction allowing users to provide additional metrics
   and their description on each scrape. See [PR 82].
+
 - Introduce a `#[prometheus(flatten)]` attribute which can be used when deriving `EncodeLabelSet`, allowing
   a nested struct to be flattened during encoding. See [PR 118].
+
   For example:
+
   ```rust
   #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
   struct CommonLabels {
@@ -25,8 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       #[prometheus(flatten)]
       common: CommonLabels,
   }
+  ```
 
-  // Would result in `my_metric{a="42",b="42",unique="42"} 42
+  Would be encoded as:
+
+  ```
+  my_metric{a="42",b="42",unique="42"} 42
   ```
 
 [PR 82]: https://github.com/prometheus/client_rust/pull/82

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = ["derive-encode"]
 dtoa = "1.0"
 itoa = "1.0"
 parking_lot = "0.12"
-prometheus-client-derive-encode = { version = "0.4.0", path = "derive-encode" }
+prometheus-client-derive-encode = { version = "0.4.1", path = "derive-encode" }
 prost = { version = "0.11.0", optional = true }
 prost-types = { version = "0.11.0", optional = true }
 

--- a/derive-encode/Cargo.toml
+++ b/derive-encode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client-derive-encode"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Auxiliary crate to derive Encode trait from prometheus-client."

--- a/derive-encode/src/lib.rs
+++ b/derive-encode/src/lib.rs
@@ -22,19 +22,24 @@ pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
             syn::Fields::Named(syn::FieldsNamed { named, .. }) => named
                 .into_iter()
                 .map(|f| {
-                    let flatten = f
+                    let attribute = f
                         .attrs
                         .iter()
                         .find(|a| a.path.is_ident("prometheus"))
-                        .map(|a| a.parse_args::<syn::Ident>().unwrap().to_string() == "flatten")
-                        .unwrap_or(false);
+                        .map(|a| a.parse_args::<syn::Ident>().unwrap().to_string());
+                    let flatten = match attribute.as_deref() {
+                        Some("flatten") => true,
+                        Some(other) => {
+                            panic!("Provided attribute '{other}', but only 'flatten' is supported")
+                        }
+                        None => false,
+                    };
+                    let ident = f.ident.unwrap();
                     if flatten {
-                        let ident = f.ident.unwrap();
                         quote! {
-                            self.#ident.encode(encoder)?;
+                             EncodeLabelSet::encode(&self.#ident, encoder)?;
                         }
                     } else {
-                        let ident = f.ident.unwrap();
                         let ident_string = KEYWORD_IDENTIFIERS
                             .iter()
                             .find(|pair| ident == pair.1)

--- a/derive-encode/src/lib.rs
+++ b/derive-encode/src/lib.rs
@@ -12,7 +12,7 @@ use quote::quote;
 use syn::DeriveInput;
 
 /// Derive `prometheus_client::encoding::EncodeLabelSet`.
-#[proc_macro_derive(EncodeLabelSet)]
+#[proc_macro_derive(EncodeLabelSet, attributes(prometheus))]
 pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
     let name = &ast.ident;
@@ -22,22 +22,35 @@ pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
             syn::Fields::Named(syn::FieldsNamed { named, .. }) => named
                 .into_iter()
                 .map(|f| {
-                    let ident = f.ident.unwrap();
-                    let ident_string = KEYWORD_IDENTIFIERS
+                    let flatten = f
+                        .attrs
                         .iter()
-                        .find(|pair| ident == pair.1)
-                        .map(|pair| pair.0.to_string())
-                        .unwrap_or_else(|| ident.to_string());
+                        .find(|a| a.path.is_ident("prometheus"))
+                        .map(|a| a.parse_args::<syn::Ident>().unwrap().to_string() == "flatten")
+                        .unwrap_or(false);
+                    if flatten {
+                        let ident = f.ident.unwrap();
+                        quote! {
+                            self.#ident.encode(encoder)?;
+                        }
+                    } else {
+                        let ident = f.ident.unwrap();
+                        let ident_string = KEYWORD_IDENTIFIERS
+                            .iter()
+                            .find(|pair| ident == pair.1)
+                            .map(|pair| pair.0.to_string())
+                            .unwrap_or_else(|| ident.to_string());
 
-                    quote! {
-                        let mut label_encoder = encoder.encode_label();
-                        let mut label_key_encoder = label_encoder.encode_label_key()?;
-                        EncodeLabelKey::encode(&#ident_string, &mut label_key_encoder)?;
+                        quote! {
+                            let mut label_encoder = encoder.encode_label();
+                            let mut label_key_encoder = label_encoder.encode_label_key()?;
+                            EncodeLabelKey::encode(&#ident_string, &mut label_key_encoder)?;
 
-                        let mut label_value_encoder = label_key_encoder.encode_label_value()?;
-                        EncodeLabelValue::encode(&self.#ident, &mut label_value_encoder)?;
+                            let mut label_value_encoder = label_key_encoder.encode_label_value()?;
+                            EncodeLabelValue::encode(&self.#ident, &mut label_value_encoder)?;
 
-                        label_value_encoder.finish()?;
+                            label_value_encoder.finish()?;
+                        }
                     }
                 })
                 .collect(),

--- a/derive-encode/tests/lib.rs
+++ b/derive-encode/tests/lib.rs
@@ -136,3 +136,41 @@ fn remap_keyword_identifiers() {
         + "# EOF\n";
     assert_eq!(expected, buffer);
 }
+
+#[test]
+fn flatten() {
+    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+    struct CommonLabels {
+        a: u64,
+        b: u64,
+    }
+    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+    struct Labels {
+        unique: u64,
+        #[prometheus(flatten)]
+        common: CommonLabels,
+    }
+
+    let mut registry = Registry::default();
+    let family = Family::<Labels, Counter>::default();
+    registry.register("my_counter", "This is my counter", family.clone());
+
+    // Record a single HTTP GET request.
+    family.get_or_create(&Labels {
+        unique: 1,
+        common: CommonLabels{
+            a: 2,
+            b: 3,
+        },
+    }).inc();
+
+    // Encode all metrics in the registry in the text format.
+    let mut buffer = String::new();
+    encode(&mut buffer, &registry).unwrap();
+
+    let expected = "# HELP my_counter This is my counter.\n".to_owned()
+        + "# TYPE my_counter counter\n"
+        + "my_counter_total{unique=\"1\",a=\"2\",b=\"3\"} 1\n"
+        + "# EOF\n";
+    assert_eq!(expected, buffer);
+}

--- a/derive-encode/tests/lib.rs
+++ b/derive-encode/tests/lib.rs
@@ -156,13 +156,12 @@ fn flatten() {
     registry.register("my_counter", "This is my counter", family.clone());
 
     // Record a single HTTP GET request.
-    family.get_or_create(&Labels {
-        unique: 1,
-        common: CommonLabels{
-            a: 2,
-            b: 3,
-        },
-    }).inc();
+    family
+        .get_or_create(&Labels {
+            unique: 1,
+            common: CommonLabels { a: 2, b: 3 },
+        })
+        .inc();
 
     // Encode all metrics in the registry in the text format.
     let mut buffer = String::new();


### PR DESCRIPTION
Fixes https://github.com/prometheus/client_rust/issues/117

This introduces a new attribute to the derive code for to flatten. This matches https://serde.rs/attr-flatten.html.

This seems to work, but I have some concern that if there are duplicate fields we end up encoding all of them which may make things go awry. Checking this is hard since we would need to lookup the type, which I am not sure how to do...