### PR TITLE
refactor(family): introduce `ConstFamily` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0]
+
+### Changed
+
+- Replace `impl EncodeMetric for RefCell<T>` with a new type `ConstFamily` implementing `EncodeMetric`.
+
 ## [0.20.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -336,7 +336,7 @@ where
 /// [`EncodeMetric::encode`] calls won't panic, they won't return any metrics as
 /// the provided [`Iterator`] will return [`Iterator::next`] [`None`]. Thus you
 /// should not return the same [`ConstFamily`] in more than one
-/// [`Collector::collect`] calls.
+/// [`Collector::collect`](crate::collector::Collector::collect) calls.
 #[derive(Debug, Default)]
 pub struct ConstFamily<I>(RefCell<I>);
 

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -330,6 +330,13 @@ where
 /// As a [`Family`], but constant, meaning it cannot change once created.
 ///
 /// Needed for advanced use-cases, e.g. in combination with [`Collector`](crate::collector::Collector).
+///
+/// Note that a [`ConstFamily`], given that it is based on an [`Iterator`], can
+/// only be [`EncodeMetric::encode`]d once. While consecutive
+/// [`EncodeMetric::encode`] calls won't panic, they won't return any metrics as
+/// the provided [`Iterator`] will return [`Iterator::next`] [`None`]. Thus you
+/// should not return the same [`ConstFamily`] in more than one
+/// [`Collector::collect`] calls.
 #[derive(Debug, Default)]
 pub struct ConstFamily<I>(RefCell<I>);
 


### PR DESCRIPTION
Addresses feedback raised by @thomaseizinger in https://github.com/prometheus/client_rust/pull/82/files#r1158205762.

@thomaseizinger this is what we discussed in Brussels. What do you think?