### PR TITLE
refactor(collector): have Registry:encode do the encoding 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - unreleased
+
+### Changed
+
+- Simplify `Collector` `trait` by enabling `Collector::collect` to encode metrics directly with a `DescriptorEncoder`.
+  See [PR 149] for details.
+
+[PR 149]: https://github.com/prometheus/client_rust/pull/149
+
 ## [0.21.2]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ prost-types = { version = "0.11.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
-criterion = "0.4"
+criterion = "0.5"
 http-types = "2"
 pyo3 = "0.18"
 quickcheck = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.21.2"
+version = "0.22.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -2,12 +2,7 @@
 //!
 //! See [`Collector`] for details.
 
-use std::borrow::Cow;
-
-use crate::{
-    registry::{Descriptor, LocalMetric},
-    MaybeOwned,
-};
+use crate::encoding::DescriptorEncoder;
 
 /// The [`Collector`] abstraction allows users to provide additional metrics and
 /// their description on each scrape.
@@ -17,13 +12,33 @@ use crate::{
 ///
 /// Register a [`Collector`] with a [`Registry`](crate::registry::Registry) via
 /// [`Registry::register_collector`](crate::registry::Registry::register_collector).
+///
+/// ```
+/// # use prometheus_client::metrics::counter::ConstCounter;
+/// # use prometheus_client::collector::Collector;
+/// # use prometheus_client::encoding::{DescriptorEncoder, EncodeMetric};
+/// #
+/// #[derive(Debug)]
+/// struct MyCollector {}
+///
+/// impl Collector for MyCollector {
+///     fn encode<'a>(&'a self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+///         let counter = ConstCounter::new(42);
+///         let metric_encoder = encoder.encode_descriptor(
+///             "my_counter",
+///             "some help",
+///             None,
+///             counter.metric_type(),
+///         )?;
+///         counter.encode(metric_encoder)?;
+///         Ok(())
+///     }
+/// }
+/// ```
 pub trait Collector: std::fmt::Debug + Send + Sync + 'static {
     /// Once the [`Collector`] is registered, this method is called on each scrape.
     ///
     /// Note that the return type allows you to either return owned (convenient)
     /// or borrowed (performant) descriptions and metrics.
-    #[allow(clippy::type_complexity)]
-    fn collect<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = (Cow<'a, Descriptor>, MaybeOwned<'a, Box<dyn LocalMetric>>)> + 'a>;
+    fn encode<'a>(&'a self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error>;
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -40,5 +40,5 @@ pub trait Collector: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// Note that the return type allows you to either return owned (convenient)
     /// or borrowed (performant) descriptions and metrics.
-    fn encode<'a>(&'a self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error>;
+    fn encode(&self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error>;
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -37,8 +37,5 @@ use crate::encoding::DescriptorEncoder;
 /// ```
 pub trait Collector: std::fmt::Debug + Send + Sync + 'static {
     /// Once the [`Collector`] is registered, this method is called on each scrape.
-    ///
-    /// Note that the return type allows you to either return owned (convenient)
-    /// or borrowed (performant) descriptions and metrics.
     fn encode(&self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error>;
 }

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -137,7 +137,8 @@ impl DescriptorEncoder<'_> {
     }
 }
 
-/// Helper type for [`EncodeMetric`], see [`EncodeMetric::encode`].
+/// Helper type for [`EncodeMetric`](super::EncodeMetric), see
+/// [`EncodeMetric::encode`](super::EncodeMetric::encode).
 ///
 // `MetricEncoder` does not take a trait parameter for `writer` and `labels`
 // because `EncodeMetric` which uses `MetricEncoder` needs to be usable as a

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -24,9 +24,10 @@
 //! assert_eq!(expected, buffer);
 //! ```
 
-use crate::encoding::{EncodeExemplarValue, EncodeLabelSet, EncodeMetric};
+use crate::encoding::{EncodeExemplarValue, EncodeLabelSet};
 use crate::metrics::exemplar::Exemplar;
-use crate::registry::{Descriptor, Registry, Unit};
+use crate::metrics::MetricType;
+use crate::registry::{Prefix, Registry, Unit};
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -38,80 +39,126 @@ pub fn encode<W>(writer: &mut W, registry: &Registry) -> Result<(), std::fmt::Er
 where
     W: Write,
 {
-    for (desc, metric) in registry.iter_metrics() {
-        encode_metric(writer, desc, metric.as_ref())?;
-    }
-    for (desc, metric) in registry.iter_collectors() {
-        encode_metric(writer, desc.as_ref(), metric.as_ref())?;
-    }
-
+    registry.encode(&mut DescriptorEncoder::new(writer).into())?;
     writer.write_str("# EOF\n")?;
-
     Ok(())
 }
 
-fn encode_metric<W>(
-    writer: &mut W,
-    desc: &Descriptor,
-    metric: &(impl EncodeMetric + ?Sized),
-) -> Result<(), std::fmt::Error>
-where
-    W: Write,
-{
-    writer.write_str("# HELP ")?;
-    writer.write_str(desc.name())?;
-    if let Some(unit) = desc.unit() {
-        writer.write_str("_")?;
-        writer.write_str(unit.as_str())?;
-    }
-    writer.write_str(" ")?;
-    writer.write_str(desc.help())?;
-    writer.write_str("\n")?;
+pub(crate) struct DescriptorEncoder<'a, 'b> {
+    writer: &'a mut dyn Write,
+    prefix: Option<&'b Prefix>,
+    labels: &'b [(Cow<'static, str>, Cow<'static, str>)],
+}
 
-    writer.write_str("# TYPE ")?;
-    writer.write_str(desc.name())?;
-    if let Some(unit) = desc.unit() {
-        writer.write_str("_")?;
-        writer.write_str(unit.as_str())?;
+impl<'a, 'b> std::fmt::Debug for DescriptorEncoder<'a, 'b> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DescriptorEncoder").finish()
     }
-    writer.write_str(" ")?;
-    writer.write_str(EncodeMetric::metric_type(metric).as_str())?;
-    writer.write_str("\n")?;
+}
 
-    if let Some(unit) = desc.unit() {
-        writer.write_str("# UNIT ")?;
-        writer.write_str(desc.name())?;
-        writer.write_str("_")?;
-        writer.write_str(unit.as_str())?;
-        writer.write_str(" ")?;
-        writer.write_str(unit.as_str())?;
-        writer.write_str("\n")?;
+impl<'a, 'b> DescriptorEncoder<'a, 'b> {
+    pub(crate) fn new(writer: &'a mut dyn Write) -> Self {
+        Self {
+            writer,
+            prefix: Default::default(),
+            labels: Default::default(),
+        }
     }
 
-    let encoder = MetricEncoder {
-        writer,
-        name: desc.name(),
-        unit: desc.unit(),
-        const_labels: desc.labels(),
-        family_labels: None,
+    pub(crate) fn with_prefix_and_labels<'c, 'd>(
+        &'c mut self,
+        prefix: Option<&'d Prefix>,
+        labels: &'d [(Cow<'static, str>, Cow<'static, str>)],
+    ) -> super::DescriptorEncoder<'c, 'd> {
+        DescriptorEncoder {
+            prefix,
+            labels,
+            writer: self.writer,
+        }
+        .into()
     }
-    .into();
 
-    EncodeMetric::encode(metric, encoder)?;
+    pub fn encode_descriptor<'c, 'd, 'e>(
+        &'c mut self,
+        name: &'d str,
+        help: &str,
+        unit: Option<&'d Unit>,
+        metric_type: MetricType,
+    ) -> Result<super::MetricEncoder<'c, 'd, 'c, 'e>, std::fmt::Error> {
+        self.writer.write_str("# HELP ")?;
+        if let Some(prefix) = self.prefix {
+            self.writer.write_str(prefix.as_str())?;
+            self.writer.write_str("_")?;
+        }
+        self.writer.write_str(name)?;
+        if let Some(unit) = unit {
+            self.writer.write_str("_")?;
+            self.writer.write_str(unit.as_str())?;
+        }
+        self.writer.write_str(" ")?;
+        self.writer.write_str(help)?;
+        self.writer.write_str("\n")?;
 
-    Ok(())
+        self.writer.write_str("# TYPE ")?;
+        if let Some(prefix) = self.prefix {
+            self.writer.write_str(prefix.as_str())?;
+            self.writer.write_str("_")?;
+        }
+        self.writer.write_str(name)?;
+        if let Some(unit) = unit {
+            self.writer.write_str("_")?;
+            self.writer.write_str(unit.as_str())?;
+        }
+        self.writer.write_str(" ")?;
+        self.writer.write_str(metric_type.as_str())?;
+        self.writer.write_str("\n")?;
+
+        if let Some(unit) = unit {
+            self.writer.write_str("# UNIT ")?;
+            if let Some(prefix) = self.prefix {
+                self.writer.write_str(prefix.as_str())?;
+                self.writer.write_str("_")?;
+            }
+            self.writer.write_str(name)?;
+            self.writer.write_str("_")?;
+            self.writer.write_str(unit.as_str())?;
+            self.writer.write_str(" ")?;
+            self.writer.write_str(unit.as_str())?;
+            self.writer.write_str("\n")?;
+        }
+
+        let encoder = MetricEncoder {
+            writer: self.writer,
+            prefix: self.prefix,
+            name,
+            unit,
+            const_labels: self.labels,
+            family_labels: None,
+        }
+        .into();
+
+        Ok(encoder)
+    }
 }
 
 /// Helper type for [`EncodeMetric`], see [`EncodeMetric::encode`].
-pub(crate) struct MetricEncoder<'a, 'b> {
+///
+// `MetricEncoder` does not take a trait parameter for `writer` and `labels`
+// because `EncodeMetric` which uses `MetricEncoder` needs to be usable as a
+// trait object in order to be able to register different metric types with a
+// `Registry`. Trait objects can not use type parameters.
+//
+// TODO: Alternative solutions to the above are very much appreciated.
+pub(crate) struct MetricEncoder<'a, 'b, 'c, 'd> {
     writer: &'a mut dyn Write,
-    name: &'a str,
-    unit: &'a Option<Unit>,
-    const_labels: &'a [(Cow<'static, str>, Cow<'static, str>)],
-    family_labels: Option<&'b dyn super::EncodeLabelSet>,
+    prefix: Option<&'c Prefix>,
+    name: &'b str,
+    unit: Option<&'b Unit>,
+    const_labels: &'c [(Cow<'static, str>, Cow<'static, str>)],
+    family_labels: Option<&'d dyn super::EncodeLabelSet>,
 }
 
-impl<'a, 'b> std::fmt::Debug for MetricEncoder<'a, 'b> {
+impl<'a, 'b, 'c, 'd> std::fmt::Debug for MetricEncoder<'a, 'b, 'c, 'd> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut labels = String::new();
         if let Some(l) = self.family_labels {
@@ -120,6 +167,7 @@ impl<'a, 'b> std::fmt::Debug for MetricEncoder<'a, 'b> {
 
         f.debug_struct("Encoder")
             .field("name", &self.name)
+            .field("prefix", &self.prefix)
             .field("unit", &self.unit)
             .field("const_labels", &self.const_labels)
             .field("labels", &labels.as_str())
@@ -127,7 +175,7 @@ impl<'a, 'b> std::fmt::Debug for MetricEncoder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> MetricEncoder<'a, 'b> {
+impl<'a, 'b, 'c, 'd> MetricEncoder<'a, 'b, 'c, 'd> {
     pub fn encode_counter<
         S: EncodeLabelSet,
         CounterValue: super::EncodeCounterValue,
@@ -137,7 +185,7 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
         v: &CounterValue,
         exemplar: Option<&Exemplar<S, ExemplarValue>>,
     ) -> Result<(), std::fmt::Error> {
-        self.write_name_and_unit()?;
+        self.write_prefix_name_unit()?;
 
         self.write_suffix("total")?;
 
@@ -163,7 +211,7 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
         &mut self,
         v: &GaugeValue,
     ) -> Result<(), std::fmt::Error> {
-        self.write_name_and_unit()?;
+        self.write_prefix_name_unit()?;
 
         self.encode_labels::<()>(None)?;
 
@@ -180,7 +228,7 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
     }
 
     pub fn encode_info<S: EncodeLabelSet>(&mut self, label_set: &S) -> Result<(), std::fmt::Error> {
-        self.write_name_and_unit()?;
+        self.write_prefix_name_unit()?;
 
         self.write_suffix("info")?;
 
@@ -196,14 +244,15 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
 
     /// Encode a set of labels. Used by wrapper metric types like
     /// [`Family`](crate::metrics::family::Family).
-    pub fn encode_family<'c, 'd, S: EncodeLabelSet>(
-        &'c mut self,
-        label_set: &'d S,
-    ) -> Result<MetricEncoder<'c, 'd>, std::fmt::Error> {
+    pub fn encode_family<'e, 'f, S: EncodeLabelSet>(
+        &'e mut self,
+        label_set: &'f S,
+    ) -> Result<MetricEncoder<'e, 'e, 'e, 'f>, std::fmt::Error> {
         debug_assert!(self.family_labels.is_none());
 
         Ok(MetricEncoder {
             writer: self.writer,
+            prefix: self.prefix,
             name: self.name,
             unit: self.unit,
             const_labels: self.const_labels,
@@ -218,14 +267,14 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
         buckets: &[(f64, u64)],
         exemplars: Option<&HashMap<usize, Exemplar<S, f64>>>,
     ) -> Result<(), std::fmt::Error> {
-        self.write_name_and_unit()?;
+        self.write_prefix_name_unit()?;
         self.write_suffix("sum")?;
         self.encode_labels::<()>(None)?;
         self.writer.write_str(" ")?;
         self.writer.write_str(dtoa::Buffer::new().format(sum))?;
         self.newline()?;
 
-        self.write_name_and_unit()?;
+        self.write_prefix_name_unit()?;
         self.write_suffix("count")?;
         self.encode_labels::<()>(None)?;
         self.writer.write_str(" ")?;
@@ -236,7 +285,7 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
         for (i, (upper_bound, count)) in buckets.iter().enumerate() {
             cummulative += count;
 
-            self.write_name_and_unit()?;
+            self.write_prefix_name_unit()?;
             self.write_suffix("bucket")?;
 
             if *upper_bound == f64::MAX {
@@ -281,7 +330,11 @@ impl<'a, 'b> MetricEncoder<'a, 'b> {
     fn newline(&mut self) -> Result<(), std::fmt::Error> {
         self.writer.write_str("\n")
     }
-    fn write_name_and_unit(&mut self) -> Result<(), std::fmt::Error> {
+    fn write_prefix_name_unit(&mut self) -> Result<(), std::fmt::Error> {
+        if let Some(prefix) = self.prefix {
+            self.writer.write_str(prefix.as_str())?;
+            self.writer.write_str("_")?;
+        }
         self.writer.write_str(self.name)?;
         if let Some(unit) = self.unit {
             self.writer.write_str("_")?;
@@ -717,6 +770,127 @@ mod tests {
             + "my_histogram_bucket{le=\"256.0\"} 1\n"
             + "my_histogram_bucket{le=\"512.0\"} 1\n"
             + "my_histogram_bucket{le=\"+Inf\"} 1\n"
+            + "# EOF\n";
+        assert_eq!(expected, encoded);
+
+        parse_with_python_client(encoded);
+    }
+
+    #[test]
+    fn sub_registry_with_prefix_and_label() {
+        let top_level_metric_name = "my_top_level_metric";
+        let mut registry = Registry::default();
+        let counter: Counter = Counter::default();
+        registry.register(top_level_metric_name, "some help", counter.clone());
+
+        let prefix_1 = "prefix_1";
+        let prefix_1_metric_name = "my_prefix_1_metric";
+        let sub_registry = registry.sub_registry_with_prefix(prefix_1);
+        sub_registry.register(prefix_1_metric_name, "some help", counter.clone());
+
+        let prefix_1_1 = "prefix_1_1";
+        let prefix_1_1_metric_name = "my_prefix_1_1_metric";
+        let sub_sub_registry = sub_registry.sub_registry_with_prefix(prefix_1_1);
+        sub_sub_registry.register(prefix_1_1_metric_name, "some help", counter.clone());
+
+        let label_1_2 = (Cow::Borrowed("registry"), Cow::Borrowed("1_2"));
+        let prefix_1_2_metric_name = "my_prefix_1_2_metric";
+        let sub_sub_registry = sub_registry.sub_registry_with_label(label_1_2.clone());
+        sub_sub_registry.register(prefix_1_2_metric_name, "some help", counter.clone());
+
+        let prefix_1_2_1 = "prefix_1_2_1";
+        let prefix_1_2_1_metric_name = "my_prefix_1_2_1_metric";
+        let sub_sub_sub_registry = sub_sub_registry.sub_registry_with_prefix(prefix_1_2_1);
+        sub_sub_sub_registry.register(prefix_1_2_1_metric_name, "some help", counter.clone());
+
+        let prefix_2 = "prefix_2";
+        let _ = registry.sub_registry_with_prefix(prefix_2);
+
+        let prefix_3 = "prefix_3";
+        let prefix_3_metric_name = "my_prefix_3_metric";
+        let sub_registry = registry.sub_registry_with_prefix(prefix_3);
+        sub_registry.register(prefix_3_metric_name, "some help", counter);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        let expected = "# HELP my_top_level_metric some help.\n".to_owned()
+            + "# TYPE my_top_level_metric counter\n"
+            + "my_top_level_metric_total 0\n"
+            + "# HELP prefix_1_my_prefix_1_metric some help.\n"
+            + "# TYPE prefix_1_my_prefix_1_metric counter\n"
+            + "prefix_1_my_prefix_1_metric_total 0\n"
+            + "# HELP prefix_1_prefix_1_1_my_prefix_1_1_metric some help.\n"
+            + "# TYPE prefix_1_prefix_1_1_my_prefix_1_1_metric counter\n"
+            + "prefix_1_prefix_1_1_my_prefix_1_1_metric_total 0\n"
+            + "# HELP prefix_1_my_prefix_1_2_metric some help.\n"
+            + "# TYPE prefix_1_my_prefix_1_2_metric counter\n"
+            + "prefix_1_my_prefix_1_2_metric_total{registry=\"1_2\"} 0\n"
+            + "# HELP prefix_1_prefix_1_2_1_my_prefix_1_2_1_metric some help.\n"
+            + "# TYPE prefix_1_prefix_1_2_1_my_prefix_1_2_1_metric counter\n"
+            + "prefix_1_prefix_1_2_1_my_prefix_1_2_1_metric_total{registry=\"1_2\"} 0\n"
+            + "# HELP prefix_3_my_prefix_3_metric some help.\n"
+            + "# TYPE prefix_3_my_prefix_3_metric counter\n"
+            + "prefix_3_my_prefix_3_metric_total 0\n"
+            + "# EOF\n";
+        assert_eq!(expected, encoded);
+
+        parse_with_python_client(encoded);
+    }
+
+    #[test]
+    fn sub_registry_collector() {
+        use crate::encoding::EncodeMetric;
+
+        #[derive(Debug)]
+        struct Collector {
+            name: String,
+        }
+
+        impl Collector {
+            fn new(name: impl Into<String>) -> Self {
+                Self { name: name.into() }
+            }
+        }
+
+        impl crate::collector::Collector for Collector {
+            fn encode<'a>(
+                &'a self,
+                mut encoder: crate::encoding::DescriptorEncoder,
+            ) -> Result<(), std::fmt::Error> {
+                let counter = crate::metrics::counter::ConstCounter::new(42);
+                let metric_encoder = encoder.encode_descriptor(
+                    &self.name,
+                    "some help",
+                    None,
+                    counter.metric_type(),
+                )?;
+                counter.encode(metric_encoder)?;
+                Ok(())
+            }
+        }
+
+        let mut registry = Registry::default();
+        registry.register_collector(Box::new(Collector::new("top_level")));
+
+        let sub_registry = registry.sub_registry_with_prefix("prefix_1");
+        sub_registry.register_collector(Box::new(Collector::new("sub_level")));
+
+        let sub_sub_registry = sub_registry.sub_registry_with_prefix("prefix_1_2");
+        sub_sub_registry.register_collector(Box::new(Collector::new("sub_sub_level")));
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        let expected = "# HELP top_level some help\n".to_owned()
+            + "# TYPE top_level counter\n"
+            + "top_level_total 42\n"
+            + "# HELP prefix_1_sub_level some help\n"
+            + "# TYPE prefix_1_sub_level counter\n"
+            + "prefix_1_sub_level_total 42\n"
+            + "# HELP prefix_1_prefix_1_2_sub_sub_level some help\n"
+            + "# TYPE prefix_1_prefix_1_2_sub_sub_level counter\n"
+            + "prefix_1_prefix_1_2_sub_sub_level_total 42\n"
             + "# EOF\n";
         assert_eq!(expected, encoded);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,28 +82,3 @@ pub mod collector;
 pub mod encoding;
 pub mod metrics;
 pub mod registry;
-
-/// Represents either borrowed or owned data.
-///
-/// In contrast to [`std::borrow::Cow`] does not require
-/// [`std::borrow::ToOwned`] or [`Clone`]respectively.
-///
-/// Needed for [`collector::Collector`].
-#[derive(Debug)]
-pub enum MaybeOwned<'a, T> {
-    /// Owned data
-    Owned(T),
-    /// Borrowed data
-    Borrowed(&'a T),
-}
-
-impl<'a, T> std::ops::Deref for MaybeOwned<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Owned(t) => t,
-            Self::Borrowed(t) => t,
-        }
-    }
-}

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 /// # use prometheus_client::encoding::text::encode;
 /// # use prometheus_client::metrics::counter::{Atomic, Counter};
 /// # use prometheus_client::metrics::family::Family;
-/// # use prometheus_client::registry::{Descriptor, Registry};
+/// # use prometheus_client::registry::Registry;
 /// #
 /// # let mut registry = Registry::default();
 /// let family = Family::<Vec<(String, String)>, Counter>::default();
@@ -65,7 +65,7 @@ use std::sync::Arc;
 /// # use prometheus_client::encoding::text::encode;
 /// # use prometheus_client::metrics::counter::{Atomic, Counter};
 /// # use prometheus_client::metrics::family::Family;
-/// # use prometheus_client::registry::{Descriptor, Registry};
+/// # use prometheus_client::registry::Registry;
 /// # use std::io::Write;
 /// #
 /// # let mut registry = Registry::default();
@@ -317,44 +317,6 @@ where
         let guard = self.read();
         for (label_set, m) in guard.iter() {
             let encoder = encoder.encode_family(label_set)?;
-            m.encode(encoder)?;
-        }
-        Ok(())
-    }
-
-    fn metric_type(&self) -> MetricType {
-        M::TYPE
-    }
-}
-
-/// As a [`Family`], but constant, meaning it cannot change once created.
-///
-/// Needed for advanced use-cases, e.g. in combination with [`Collector`](crate::collector::Collector).
-///
-/// Note that a [`ConstFamily`], given that it is based on an [`Iterator`], can
-/// only be [`EncodeMetric::encode`]d once. While consecutive
-/// [`EncodeMetric::encode`] calls won't panic, they won't return any metrics as
-/// the provided [`Iterator`] will return [`Iterator::next`] [`None`]. Thus you
-/// should not return the same [`ConstFamily`] in more than one
-/// [`Collector::collect`](crate::collector::Collector::collect) calls.
-#[derive(Debug, Default)]
-pub struct ConstFamily<I>(RefCell<I>);
-
-impl<I> ConstFamily<I> {
-    /// Creates a new [`ConstFamily`].
-    pub fn new(iter: I) -> Self {
-        Self(RefCell::new(iter))
-    }
-}
-
-impl<S: EncodeLabelSet, M: EncodeMetric + TypedMetric, I: Iterator<Item = (S, M)>> EncodeMetric
-    for ConstFamily<I>
-{
-    fn encode(&self, mut encoder: MetricEncoder<'_, '_>) -> Result<(), std::fmt::Error> {
-        let mut iter = self.0.borrow_mut();
-
-        for (label_set, m) in iter.by_ref() {
-            let encoder = encoder.encode_family(&label_set)?;
             m.encode(encoder)?;
         }
         Ok(())

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -6,7 +6,6 @@ use crate::encoding::{EncodeLabelSet, EncodeMetric, MetricEncoder};
 
 use super::{MetricType, TypedMetric};
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 


### PR DESCRIPTION
Let's face it, the `Collector` trait I designed in https://github.com/prometheus/client_rust/pull/82 is too complex.

Instead of having `Registry` provide access to its inner `Metric`s, have
`Registry` encode the `Metric`s directly via `Registry::encode`. In the same
vain, have `Collector::encode` encode the collected `Metric`s directly.

This allows for a much simpler `Collector` trait, removing all complexity due to
providing access to a `Metric` externally.

``` rust
/// The [`Collector`] abstraction allows users to provide additional metrics and
/// their description on each scrape.
///
/// An example use-case is an exporter that retrieves a set of operating system metrics
/// ad-hoc on each scrape.
///
/// Register a [`Collector`] with a [`Registry`](crate::registry::Registry) via
/// [`Registry::register_collector`](crate::registry::Registry::register_collector).
///
/// ```
/// # use prometheus_client::metrics::counter::ConstCounter;
/// # use prometheus_client::collector::Collector;
/// # use prometheus_client::encoding::{DescriptorEncoder, EncodeMetric};
/// #
/// #[derive(Debug)]
/// struct MyCollector {}
///
/// impl Collector for MyCollector {
///     fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
///         let counter = ConstCounter::new(42);
///         let metric_encoder = encoder.encode_descriptor(
///             "my_counter",
///             "some help",
///             None,
///             counter.metric_type(),
///         )?;
///         counter.encode(metric_encoder)?;
///         Ok(())
///     }
/// }
/// ```
pub trait Collector: std::fmt::Debug + Send + Sync + 'static {
    /// Once the [`Collector`] is registered, this method is called on each scrape.
    fn encode<'a>(&'a self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error>;
}
```