### PR TITLE
feat(encoding): new `encode_registry` and `encode_end` functions to compose cross-registry responses

### DIFF
--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -57,6 +57,7 @@ pub fn encode<W>(writer: &mut W, registry: &Registry) -> Result<(), std::fmt::Er
 /// # use prometheus_client::metrics::counter::Counter;
 /// # use prometheus_client::metrics::histogram::{Histogram, exponential_buckets};
 /// # use prometheus_client::registry::Registry;
+/// # use prometheus_client::registry::Unit;
 /// # use prometheus_client::encoding::text::{encode_registry, encode_end};
 /// #
 /// # fn main() -> Result<(), std::fmt::Error> {

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -36,8 +36,8 @@ use std::fmt::Write;
 /// Encode the metrics registered with the provided [`Registry`] into the
 /// provided [`Write`]r using the OpenMetrics text format.
 pub fn encode<W>(writer: &mut W, registry: &Registry) -> Result<(), std::fmt::Error>
-    where
-        W: Write,
+where
+    W: Write,
 {
     encode_registry(writer, registry)?;
     encode_end(writer)

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -58,9 +58,10 @@ use std::fmt::Write;
 ///     "Total orders received",
 ///     total_orders.clone(),
 /// );
-/// orders_registry.register(
+/// orders_registry.register_with_unit(
 ///     "processing_times",
-///     "Order times in seconds",
+///     "Order times",
+///     Unit::Seconds,
 ///     processing_times.clone(),
 /// );
 ///

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -33,6 +33,16 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Write;
 
+/// Encode the metrics registered with the provided [`Registry`] into the
+/// provided [`Write`]r using the OpenMetrics text format.
+pub fn encode<W>(writer: &mut W, registry: &Registry) -> Result<(), std::fmt::Error>
+    where
+        W: Write,
+{
+    encode_registry(writer, registry)?;
+    encode_end(writer)
+}
+
 /// Encode the metrics registered with the provided
 /// [`Registry`] into the provided [`Write`]r using the OpenMetrics text
 /// format.
@@ -110,16 +120,6 @@ where
 {
     writer.write_str("# EOF\n")?;
     Ok(())
-}
-
-/// Encode the metrics registered with the provided [`Registry`] into the
-/// provided [`Write`]r using the OpenMetrics text format.
-pub fn encode<W>(writer: &mut W, registry: &Registry) -> Result<(), std::fmt::Error>
-where
-    W: Write,
-{
-    encode_registry(writer, registry)?;
-    encode_end(writer)
 }
 
 pub(crate) struct DescriptorEncoder<'a> {


### PR DESCRIPTION
New `encode_registry` and `encode_end` functions allow encoding only parts of the response.

This is useful when there are multiple registries at play, or when composing metrics for a process that embeds Rust as part of its logic whilst serving metrics to Prometheus outside of Rust.

Closes https://github.com/prometheus/client_rust/issues/153

------------

_I wish to waive any ownership rights for the changes included in this PR and I'm happy for you to license these changes in any way you see fit, including the MIT and Apache licenses. Once accepted these changes are of your ownership._