### PR TITLE
feat(family): add ability to lookup metric by query type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = ["derive-encode"]
 
 [dependencies]
 dtoa = "1.0"
+hashbrown = "0.14"
 itoa = "1.0"
 parking_lot = "0.12"
 prometheus-client-derive-encode = { version = "0.4.1", path = "derive-encode" }

--- a/benches/family.rs
+++ b/benches/family.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::family::{CreateFromEquivalent, Equivalent, Family};
 
 pub fn family(c: &mut Criterion) {
     c.bench_function("counter family with Vec<(String, String)> label set", |b| {
@@ -49,6 +50,79 @@ pub fn family(c: &mut Criterion) {
                 .inc();
         })
     });
+
+    c.bench_function(
+        "counter family with custom type label set and direct lookup",
+        |b| {
+            #[derive(Clone, Eq, Hash, PartialEq, EncodeLabelSet)]
+            struct Labels {
+                method: String,
+                url_path: String,
+                status_code: String,
+            }
+
+            let family = Family::<Labels, Counter>::default();
+
+            b.iter(|| {
+                family
+                    .get_or_create(&Labels {
+                        method: "GET".to_string(),
+                        url_path: "/metrics".to_string(),
+                        status_code: "200".to_string(),
+                    })
+                    .inc();
+            })
+        },
+    );
+
+    c.bench_function(
+        "counter family with custom type label set and equivalent lookup",
+        |b| {
+            #[derive(Clone, Eq, Hash, PartialEq, EncodeLabelSet)]
+            struct Labels {
+                method: String,
+                url_path: String,
+                status_code: String,
+            }
+
+            #[derive(Debug, Eq, Hash, PartialEq)]
+            struct LabelsQ<'a> {
+                method: &'a str,
+                url_path: &'a str,
+                status_code: &'a str,
+            }
+
+            impl CreateFromEquivalent<Labels> for LabelsQ<'_> {
+                fn create(&self) -> Labels {
+                    Labels {
+                        method: self.method.to_string(),
+                        url_path: self.url_path.to_string(),
+                        status_code: self.status_code.to_string(),
+                    }
+                }
+            }
+
+            impl Equivalent<Labels> for LabelsQ<'_> {
+                fn equivalent(&self, key: &Labels) -> bool {
+                    self.method == key.method
+                        && self.url_path == key.url_path
+                        && self.status_code == key.status_code
+                }
+            }
+
+            let family = Family::<Labels, Counter>::default();
+
+            b.iter(|| {
+                family
+                    .get_or_create(&LabelsQ {
+                        method: "GET",
+                        url_path: "/metrics",
+                        status_code: "200",
+                    })
+                    .inc();
+            })
+        },
+    );
 }
 
 criterion_group!(benches, family);


### PR DESCRIPTION
Added ability to lookup metric by query type in `Family::get_or_create`

Example:
```rust
#[derive(Clone, Eq, Hash, PartialEq, EncodeLabelSet)]
struct Labels {
    method: String,
    url_path: String,
    status_code: String,
}

let family = Family::<Labels, Counter>::default();

// Will create or get the metric with label `method="GET",url_path="/metrics",status_code="200"`
family.get_or_create(&Labels {
    method: "GET".to_string(),
    url_path: "/metrics".to_string(),
    status_code: "200".to_string(),
}).inc();

// Will return a reference to the metric without unnecessary cloning and allocation.
family.get_or_create(&LabelsQ {
    method: "GET",
    url_path: "/metrics",
    status_code: "200",
}).inc();

#[derive(Debug, Eq, Hash, PartialEq)]
struct LabelsQ<'a> {
    method: &'a str,
    url_path: &'a str,
    status_code: &'a str,
}

impl CreateFromEquivalent<Labels> for LabelsQ<'_> {
    fn create(&self) -> Labels {
        Labels {
            method: self.method.to_string(),
            url_path: self.url_path.to_string(),
            status_code: self.status_code.to_string(),
        }
    }
}

impl Equivalent<Labels> for LabelsQ<'_> {
    fn equivalent(&self, key: &Labels) -> bool {
        self.method == key.method &&
            self.url_path == key.url_path &&
            self.status_code == key.status_code
    }
}
```
Performance difference:
* *61.247* ns - lookup by `&Labels {method: "GET".to_string(), url_path: "/metrics".to_string(), status_code: "200".to_string()}`
* *13.324 ns* - lookup by `&LabelsQ {method: "GET", url_path: "/metrics", status_code: "200"}`

```
counter family with custom type label set and direct lookup
                        time:   [61.076 ns 61.247 ns 61.422 ns]
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe

counter family with custom type label set and equivalent lookup
                        time:   [13.291 ns 13.324 ns 13.358 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

```

Fix: #157 
