### PR TITLE
feat(encoding): add impls for `Encode*Value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [PR 198]: https://github.com/prometheus/client_rust/pull/198
 
+- Add `EncodeGaugeValue` `i32` and `f32`, `EncodeCounterValue` `u32` and `f32` and `EncodeExemplarValue` `f32` and `u32` implementations.
+  See [PR 173].
+
+[PR 173]: https://github.com/prometheus/client_rust/pull/173
+
 ## [0.22.3]
 
 ### Added

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -23,7 +23,7 @@ use crate::encoding::DescriptorEncoder;
 ///
 /// impl Collector for MyCollector {
 ///     fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
-///         let counter = ConstCounter::new(42);
+///         let counter = ConstCounter::new(42u64);
 ///         let metric_encoder = encoder.encode_descriptor(
 ///             "my_counter",
 ///             "some help",

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -500,6 +500,18 @@ impl EncodeGaugeValue for f64 {
     }
 }
 
+impl EncodeGaugeValue for i32 {
+    fn encode(&self, encoder: &mut GaugeValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.encode_i64(*self as i64)
+    }
+}
+
+impl EncodeGaugeValue for f32 {
+    fn encode(&self, encoder: &mut GaugeValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.encode_f64(*self as f64)
+    }
+}
+
 /// Encoder for a gauge value.
 #[derive(Debug)]
 pub struct GaugeValueEncoder<'a>(GaugeValueEncoderInner<'a>);
@@ -552,6 +564,18 @@ impl EncodeCounterValue for f64 {
     }
 }
 
+impl EncodeCounterValue for u32 {
+    fn encode(&self, encoder: &mut CounterValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.encode_u64(*self as u64)
+    }
+}
+
+impl EncodeCounterValue for f32 {
+    fn encode(&self, encoder: &mut CounterValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.encode_f64(*self as f64)
+    }
+}
+
 /// Encoder for a counter value.
 #[derive(Debug)]
 pub struct CounterValueEncoder<'a>(CounterValueEncoderInner<'a>);
@@ -586,6 +610,18 @@ impl EncodeExemplarValue for f64 {
 }
 
 impl EncodeExemplarValue for u64 {
+    fn encode(&self, mut encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.encode(*self as f64)
+    }
+}
+
+impl EncodeExemplarValue for f32 {
+    fn encode(&self, mut encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.encode(*self as f64)
+    }
+}
+
+impl EncodeExemplarValue for u32 {
     fn encode(&self, mut encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode(*self as f64)
     }

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -1014,7 +1014,7 @@ mod tests {
                 &self,
                 mut encoder: crate::encoding::DescriptorEncoder,
             ) -> Result<(), std::fmt::Error> {
-                let counter = crate::metrics::counter::ConstCounter::new(42);
+                let counter = crate::metrics::counter::ConstCounter::new(42u64);
                 let metric_encoder = encoder.encode_descriptor(
                     &self.name,
                     "some help",

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -185,7 +185,7 @@ impl Registry {
     ///
     /// impl Collector for MyCollector {
     ///     fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
-    ///         let counter = ConstCounter::new(42);
+    ///         let counter = ConstCounter::new(42u64);
     ///         let metric_encoder = encoder.encode_descriptor(
     ///             "my_counter",
     ///             "some help",


### PR DESCRIPTION
With these changes, I no longer get the error:

> trait `EncodeCounterValue` is not implemented for `u32`

when compiling to mips.

I have also added additional trait implementations for the other types. The reason to cast from 32 to 64 bit values is that in the end, it is casted to 64 bit values anyway, because these are the types that must be used: https://github.com/prometheus/client_rust/blob/master/src/encoding/proto/openmetrics_data_model.proto. This way, there is no need to implement `encoder.encode_u32` ... methods.

I believe this is not catched by the tests, because the library itself compiles fine to mips, until you start implementing it. Unfortunately the cross-compile check does not run the tests. I did a quick test changing the `cargo check ...` to `cargo check --target=${{ matrix.target }} --tests`, but this will return errors because the dev-dependency `pyo3` a bit more than just the Rust toolchain for mips is required.

Fixes #172.