### PR TITLE
feat(encoding): implement `EncodeLabelKey` and `EncodeLabelValue` for `Arc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `EncodeLabelValue` and `EncodeLabelKey` implementations for `Arc`,
   `Rc`, and `Box`.
+  See [PR 188].
 
 [PR 188]: https://github.com/prometheus/client_rust/pull/188
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.1]
+
+### Added
+
+- Added `EncodeLabelValue` and `EncodeLabelKey` implementations for `Arc`,
+  `Rc`, and `Box`.
+
+[PR 188]: https://github.com/prometheus/client_rust/pull/188
+
 ## [0.22.0]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -9,6 +9,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::ops::Deref;
+use std::rc::Rc;
+use std::sync::Arc;
 
 #[cfg(feature = "protobuf")]
 pub mod protobuf;
@@ -389,6 +391,33 @@ impl<'a> EncodeLabelKey for Cow<'a, str> {
     }
 }
 
+impl<T> EncodeLabelKey for Box<T>
+where
+    for<'a> &'a T: EncodeLabelKey,
+{
+    fn encode(&self, encoder: &mut LabelKeyEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelKey::encode(&self.as_ref(), encoder)
+    }
+}
+
+impl<T> EncodeLabelKey for Arc<T>
+where
+    for<'a> &'a T: EncodeLabelKey,
+{
+    fn encode(&self, encoder: &mut LabelKeyEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelKey::encode(&self.as_ref(), encoder)
+    }
+}
+
+impl<T> EncodeLabelKey for Rc<T>
+where
+    for<'a> &'a T: EncodeLabelKey,
+{
+    fn encode(&self, encoder: &mut LabelKeyEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelKey::encode(&self.as_ref(), encoder)
+    }
+}
+
 /// An encodable label value.
 pub trait EncodeLabelValue {
     /// Encode oneself into the given encoder.
@@ -445,6 +474,33 @@ impl EncodeLabelValue for String {
 }
 
 impl<'a> EncodeLabelValue for Cow<'a, str> {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_ref(), encoder)
+    }
+}
+
+impl<T> EncodeLabelValue for Box<T>
+where
+    for<'a> &'a T: EncodeLabelValue,
+{
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_ref(), encoder)
+    }
+}
+
+impl<T> EncodeLabelValue for Arc<T>
+where
+    for<'a> &'a T: EncodeLabelValue,
+{
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_ref(), encoder)
+    }
+}
+
+impl<T> EncodeLabelValue for Rc<T>
+where
+    for<'a> &'a T: EncodeLabelValue,
+{
     fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
         EncodeLabelValue::encode(&self.as_ref(), encoder)
     }


### PR DESCRIPTION
Adds blanket implementations to encode reference-counted keys and values.