### PR TITLE
chore(examples/hyper):  Port to hyper 1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tide = "0.16"
 actix-web = "4"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal"] }
 hyper = { version = "1.3.1", features = ["server", "http1"] }
-hyper-util = { version = "0.1.3", features = ["full"] }
+hyper-util = { version = "0.1.3", features = ["tokio"] }
 http-body-util = "0.1.1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,9 @@ rand = "0.8.4"
 tide = "0.16"
 actix-web = "4"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal"] }
-hyper = { version = "0.14.16", features = ["server", "http1", "tcp"] }
+hyper = { version = "1.3.1", features = ["server", "http1"] }
+hyper-util = { version = "0.1.3", features = ["full"] }
+http-body-util = "0.1.1"
 
 [build-dependencies]
 prost-build = { version = "0.11.0", optional = true }

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -1,10 +1,11 @@
+use http_body_util::{combinators, BodyExt, Full};
 use hyper::{
-    service::service_fn,
-    Request, Response, body::{Incoming, Bytes},
+    body::{Bytes, Incoming},
     server::conn::http1,
+    service::service_fn,
+    Request, Response,
 };
 use hyper_util::rt::TokioIo;
-use http_body_util::{combinators, Full, BodyExt};
 use prometheus_client::{encoding::text::encode, metrics::counter::Counter, registry::Registry};
 use std::{
     future::Future,
@@ -13,7 +14,11 @@ use std::{
     pin::Pin,
     sync::Arc,
 };
-use tokio::{pin, net::TcpListener, signal::unix::{signal, SignalKind}};
+use tokio::{
+    net::TcpListener,
+    pin,
+    signal::unix::{signal, SignalKind},
+};
 
 #[tokio::main]
 async fn main() {
@@ -64,7 +69,8 @@ type BoxBody = combinators::BoxBody<Bytes, hyper::Error>;
 /// This function returns a HTTP handler (i.e. another function)
 pub fn make_handler(
     registry: Arc<Registry>,
-) -> impl Fn(Request<Incoming>) -> Pin<Box<dyn Future<Output = io::Result<Response<BoxBody>>> + Send>> {
+) -> impl Fn(Request<Incoming>) -> Pin<Box<dyn Future<Output = io::Result<Response<BoxBody>>> + Send>>
+{
     // This closure accepts a request and responds with the OpenMetrics encoding of our metrics.
     move |_req: Request<Incoming>| {
         let reg = registry.clone();


### PR DESCRIPTION
This PR ports the hyper example to hyper 1.x.
All kudos goes to @junkurihara (https://github.com/prometheus/client_rust/pull/184).

Closes the erroneous https://github.com/prometheus/client_rust/pull/187.