### PR TITLE
Add clear/reset methods for histograms and counters

### DIFF
--- a/src/encoding/protobuf.rs
+++ b/src/encoding/protobuf.rs
@@ -739,6 +739,35 @@ mod tests {
                 );
                 assert_eq!(1, value.count);
                 assert_eq!(11, value.buckets.len());
+                assert_eq!(1u64, value.buckets.iter().map(|bucket| bucket.count).sum());
+            }
+            _ => panic!("wrong value type"),
+        }
+
+        histogram.clear();
+
+        let metric_set = encode(&registry).unwrap();
+
+        let family = metric_set.metric_families.first().unwrap();
+        assert_eq!("my_histogram", family.name);
+        assert_eq!("My histogram.", family.help);
+
+        assert_eq!(
+            openmetrics_data_model::MetricType::Histogram as i32,
+            extract_metric_type(&metric_set)
+        );
+
+        match extract_metric_point_value(&metric_set) {
+            openmetrics_data_model::metric_point::Value::HistogramValue(value) => {
+                assert_eq!(
+                    Some(openmetrics_data_model::histogram_value::Sum::DoubleValue(
+                        0.0
+                    )),
+                    value.sum
+                );
+                assert_eq!(0, value.count);
+                assert_eq!(11, value.buckets.len());
+                assert_eq!(0u64, value.buckets.iter().map(|bucket| bucket.count).sum());
             }
             _ => panic!("wrong value type"),
         }

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -101,6 +101,17 @@ impl Histogram {
         }
     }
 
+    /// Clears all observations.
+    pub fn clear(&self) {
+        let mut inner = self.inner.write();
+        inner.sum = Default::default();
+        inner.count = Default::default();
+
+        for (_, value) in &mut inner.buckets {
+            *value = 0;
+        }
+    }
+
     pub(crate) fn get(&self) -> (f64, u64, MappedRwLockReadGuard<Vec<(f64, u64)>>) {
         let inner = self.inner.read();
         let sum = inner.sum;
@@ -149,6 +160,7 @@ mod tests {
     fn histogram() {
         let histogram = Histogram::new(exponential_buckets(1.0, 2.0, 10));
         histogram.observe(1.0);
+        histogram.clear();
     }
 
     #[test]


### PR DESCRIPTION
Thanks for this great project! I noticed that [families have a `clear` method](https://docs.rs/prometheus-client/0.22.2/prometheus_client/metrics/family/struct.Family.html#method.clear), but nothing like this exists for histograms and counters. I figured out that you can get around this for counters with `.inner().store(0, Ordering::Relaxed)` (although using `.inner()` does not feel so nice to me), but I couldn't find a way to do this for histograms.

I've found that clearing/resetting metrics is particularly useful for testing, to avoid needing to compare each metric to the value it was at the beginning of the test. Therefore, I've added methods to clear/reset histograms and counters in this PR. I'm also happy to first create an issue if some discussion on adding these methods is needed.