### PR TITLE
chore(portability): Support 32 bit RISC-V

### DIFF
--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -6,7 +6,7 @@ use crate::encoding::{EncodeMetric, MetricEncoder};
 
 use super::{MetricType, TypedMetric};
 use std::marker::PhantomData;
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -40,7 +40,7 @@ use std::sync::Arc;
 /// counter.inc();
 /// let _value: f64 = counter.get();
 /// ```
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 #[derive(Debug)]
 pub struct Counter<N = u64, A = AtomicU64> {
     value: Arc<A>,
@@ -48,7 +48,7 @@ pub struct Counter<N = u64, A = AtomicU64> {
 }
 
 /// Open Metrics [`Counter`] to measure discrete events.
-#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+#[cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32"))]
 #[derive(Debug)]
 pub struct Counter<N = u32, A = AtomicU32> {
     value: Arc<A>,
@@ -114,7 +114,7 @@ pub trait Atomic<N> {
     fn get(&self) -> N;
 }
 
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 impl Atomic<u64> for AtomicU64 {
     fn inc(&self) -> u64 {
         self.inc_by(1)
@@ -143,7 +143,7 @@ impl Atomic<u32> for AtomicU32 {
     }
 }
 
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 impl Atomic<f64> for AtomicU64 {
     fn inc(&self) -> f64 {
         self.inc_by(1.0)
@@ -231,7 +231,7 @@ mod tests {
         assert_eq!(1, counter.get());
     }
 
-    #[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+    #[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
     #[test]
     fn f64_stored_in_atomic_u64() {
         fn prop(fs: Vec<f64>) {

--- a/src/metrics/exemplar.rs
+++ b/src/metrics/exemplar.rs
@@ -11,9 +11,9 @@ use super::histogram::Histogram;
 use super::{MetricType, TypedMetric};
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
 use std::collections::HashMap;
-#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+#[cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32"))]
 use std::sync::atomic::AtomicU32;
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
@@ -65,7 +65,7 @@ pub struct Exemplar<S, V> {
 ///         }),
 ///     );
 /// ```
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 #[derive(Debug)]
 pub struct CounterWithExemplar<S, N = u64, A = AtomicU64> {
     pub(crate) inner: Arc<RwLock<CounterWithExemplarInner<S, N, A>>>,
@@ -77,7 +77,7 @@ impl<S> TypedMetric for CounterWithExemplar<S> {
 
 /// Open Metrics [`Counter`] with an [`Exemplar`] to both measure discrete
 /// events and track references to data outside of the metric set.
-#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+#[cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32"))]
 #[derive(Debug)]
 pub struct CounterWithExemplar<S, N = u32, A = AtomicU32> {
     pub(crate) inner: Arc<RwLock<CounterWithExemplarInner<S, N, A>>>,

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -7,7 +7,7 @@ use crate::encoding::{EncodeGaugeValue, EncodeMetric, MetricEncoder};
 use super::{MetricType, TypedMetric};
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicI32, AtomicU32, Ordering};
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 use std::sync::atomic::{AtomicI64, AtomicU64};
 use std::sync::Arc;
 
@@ -40,7 +40,7 @@ use std::sync::Arc;
 /// gauge.set(42.0);
 /// let _value: f64 = gauge.get();
 /// ```
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 #[derive(Debug)]
 pub struct Gauge<N = i64, A = AtomicI64> {
     value: Arc<A>,
@@ -48,7 +48,7 @@ pub struct Gauge<N = i64, A = AtomicI64> {
 }
 
 /// Open Metrics [`Gauge`] to record current measurements.
-#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+#[cfg(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32"))]
 #[derive(Debug)]
 pub struct Gauge<N = i32, A = AtomicI32> {
     value: Arc<A>,
@@ -186,7 +186,7 @@ impl Atomic<u32> for AtomicU32 {
     }
 }
 
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 impl Atomic<i64> for AtomicI64 {
     fn inc(&self) -> i64 {
         self.inc_by(1)
@@ -213,7 +213,7 @@ impl Atomic<i64> for AtomicI64 {
     }
 }
 
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", target_arch = "riscv32")))]
 impl Atomic<f64> for AtomicU64 {
     fn inc(&self) -> f64 {
         self.inc_by(1.0)


### PR DESCRIPTION
Adds `target_arch = "riscv32"` to the list of AtomicU64 exclusions.

This is a narrow fix for #201.