### PR TITLE
feat(encoding): add functions for individually encoding registry & EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.4]
+
+### Added
+
+- Added `encode_registry` and `encode_eof` functions to `text` module.
+  See [PR 205].
+
+[PR 205]: https://github.com/prometheus/client_rust/pull/205
+
 ## [0.22.3] - unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.22.4]
+## [0.22.3] - unreleased
 
 ### Added
 
 - Added `encode_registry` and `encode_eof` functions to `text` module.
   See [PR 205].
-
-[PR 205]: https://github.com/prometheus/client_rust/pull/205
-
-## [0.22.3] - unreleased
-
-### Added
+  
+  [PR 205]: https://github.com/prometheus/client_rust/pull/205
 
 - Support all platforms with 32 bit atomics lacking 64 bit atomics.
   See [PR 203].

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.22.4"
+version = "0.22.3"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.22.2"
+version = "0.22.4"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."


### PR DESCRIPTION
**Note: All credits for the PR, from the initial idea, implementation, and testing, belong to @amunra who is the original author of this PR and #154.**

From the original PR description:

Adds new `encode_registry` and `encode_eof` functions to allow encoding of parts of the response.

This is useful when there are multiple registries at play, or when composing metrics for a process that embeds Rust as part of its logic whilst serving metrics to Prometheus outside of Rust.

Fixes: #153
Refs: #154, #204

Thank you @amunra! 😸