### PR TITLE
Added `Counter<u32, AtomicU32>` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support all platforms with 32 bit atomics lacking 64 bit atomics.
   See [PR 203].
+- Added `Counter<u32, AtomicU32>` implementation.
+  See [PR 206].
 
 [PR 203]: https://github.com/prometheus/client_rust/pull/203
+[PR 206]: https://github.com/prometheus/client_rust/pull/206
 
 ## [0.22.2]
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -23,7 +23,7 @@ use crate::encoding::DescriptorEncoder;
 ///
 /// impl Collector for MyCollector {
 ///     fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
-///         let counter = ConstCounter::new(42);
+///         let counter = ConstCounter::new(42u64);
 ///         let metric_encoder = encoder.encode_descriptor(
 ///             "my_counter",
 ///             "some help",

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -606,6 +606,12 @@ pub trait EncodeCounterValue {
     fn encode(&self, encoder: &mut CounterValueEncoder) -> Result<(), std::fmt::Error>;
 }
 
+impl EncodeCounterValue for u32 {
+    fn encode(&self, encoder: &mut CounterValueEncoder) -> Result<(), std::fmt::Error> {
+        encoder.encode_u32(*self)
+    }
+}
+
 impl EncodeCounterValue for u64 {
     fn encode(&self, encoder: &mut CounterValueEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode_u64(*self)
@@ -630,6 +636,10 @@ enum CounterValueEncoderInner<'a> {
 }
 
 impl<'a> CounterValueEncoder<'a> {
+    fn encode_u32(&mut self, v: u32) -> Result<(), std::fmt::Error> {
+        for_both_mut!(self, CounterValueEncoderInner, e, e.encode_u32(v))
+    }
+
     fn encode_f64(&mut self, v: f64) -> Result<(), std::fmt::Error> {
         for_both_mut!(self, CounterValueEncoderInner, e, e.encode_f64(v))
     }

--- a/src/encoding/protobuf.rs
+++ b/src/encoding/protobuf.rs
@@ -365,6 +365,10 @@ pub(crate) struct CounterValueEncoder<'a> {
 }
 
 impl<'a> CounterValueEncoder<'a> {
+    pub fn encode_u32(&mut self, v: u32) -> Result<(), std::fmt::Error> {
+        self.encode_u64(v as u64)
+    }
+
     pub fn encode_f64(&mut self, v: f64) -> Result<(), std::fmt::Error> {
         *self.value = openmetrics_data_model::counter_value::Total::DoubleValue(v);
         Ok(())

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -399,6 +399,12 @@ impl<'a> std::fmt::Debug for CounterValueEncoder<'a> {
 }
 
 impl<'a> CounterValueEncoder<'a> {
+    pub fn encode_u32(&mut self, v: u32) -> Result<(), std::fmt::Error> {
+        self.writer.write_str(" ")?;
+        self.writer.write_str(itoa::Buffer::new().format(v))?;
+        Ok(())
+    }
+
     pub fn encode_f64(&mut self, v: f64) -> Result<(), std::fmt::Error> {
         self.writer.write_str(" ")?;
         self.writer.write_str(dtoa::Buffer::new().format(v))?;
@@ -578,6 +584,9 @@ mod tests {
         let counter: Counter = Counter::default();
         let mut registry = Registry::default();
         registry.register("my_counter", "My counter", counter);
+
+        let counter_u32 = Counter::<u32, AtomicU32>::default();
+        registry.register("u32_counter", "Counter::<u32, AtomicU32>", counter_u32);
 
         let mut encoded = String::new();
 
@@ -876,7 +885,7 @@ mod tests {
                 &self,
                 mut encoder: crate::encoding::DescriptorEncoder,
             ) -> Result<(), std::fmt::Error> {
-                let counter = crate::metrics::counter::ConstCounter::new(42);
+                let counter = crate::metrics::counter::ConstCounter::new(42u64);
                 let metric_encoder = encoder.encode_descriptor(
                     &self.name,
                     "some help",

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -185,7 +185,7 @@ impl Registry {
     ///
     /// impl Collector for MyCollector {
     ///     fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
-    ///         let counter = ConstCounter::new(42);
+    ///         let counter = ConstCounter::new(42u64);
     ///         let metric_encoder = encoder.encode_descriptor(
     ///             "my_counter",
     ///             "some help",


### PR DESCRIPTION
This is useful for platforms that don’t support 64bit, such as a number of std-enabled networked MCUs.

I have unfortunately not been able to test the protobuf part, as I’m unable to build it (something about `protoc failed: google/protobuf/timestamp.proto: File not found.`). Hope CI will test it !