### PR TITLE
docs: enable for protobuf feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,8 @@ name = "proto"
 path = "benches/encoding/proto.rs"
 harness = false
 required-features = ["protobuf"]
+
+# Passing arguments to the docsrs builder in order to properly document cfg's.
+# More information: https://docs.rs/about/builds#cross-compiling
+[package.metadata.docs.rs]
+all-features = true

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 #[cfg(feature = "protobuf")]
+#[cfg_attr(docsrs, doc(cfg(feature = "protobuf")))]
 pub mod protobuf;
 pub mod text;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(unused)]
 #![forbid(unsafe_code)]
 #![warn(missing_debug_implementations)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Client library implementation of the [Open Metrics
 //! specification](https://github.com/OpenObservability/OpenMetrics). Allows


### PR DESCRIPTION
- have docs.rs generate  with `protobuf` feature
- flag that only enabled with `protobuf` feature