### PR TITLE
chore(deps): update prost dependencies to v0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.22.3] - unreleased
+## [0.23.0] - unreleased
 
 ### Added
 
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   See [PR 203].
 
 [PR 203]: https://github.com/prometheus/client_rust/pull/203
+
+- Update `prost` dependencies to `v0.12`.
+  See [PR 198].
+
+[PR 198]: https://github.com/prometheus/client_rust/pull/198
 
 ## [0.22.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.23.0] - unreleased
 
+- Update `prost` dependencies to `v0.12`.
+  See [PR 198].
+
+[PR 198]: https://github.com/prometheus/client_rust/pull/198
+
+## [0.22.3]
+
 ### Added
 
 - Added `encode_registry` and `encode_eof` functions to `text` module.
   See [PR 205].
-  
+
   [PR 205]: https://github.com/prometheus/client_rust/pull/205
 
 - Support all platforms with 32 bit atomics lacking 64 bit atomics.
   See [PR 203].
 
 [PR 203]: https://github.com/prometheus/client_rust/pull/203
-
-- Update `prost` dependencies to `v0.12`.
-  See [PR 198].
-
-[PR 198]: https://github.com/prometheus/client_rust/pull/198
 
 ## [0.22.2]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.0"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ dtoa = "1.0"
 itoa = "1.0"
 parking_lot = "0.12"
 prometheus-client-derive-encode = { version = "0.4.1", path = "derive-encode" }
-prost = { version = "0.11.0", optional = true }
-prost-types = { version = "0.11.0", optional = true }
+prost = { version = "0.12.0", optional = true }
+prost-types = { version = "0.12.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
 criterion = "0.5"
 http-types = "2"
-pyo3 = "0.20"
+pyo3 = "0.21"
 quickcheck = "1"
 rand = "0.8.4"
 tide = "0.16"
@@ -40,7 +40,7 @@ hyper-util = { version = "0.1.3", features = ["tokio"] }
 http-body-util = "0.1.1"
 
 [build-dependencies]
-prost-build = { version = "0.11.0", optional = true }
+prost-build = { version = "0.12.0", optional = true }
 
 [[bench]]
 name = "baseline"

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -920,7 +920,7 @@ mod tests {
 
         println!("{:?}", input);
         Python::with_gil(|py| {
-            let parser = PyModule::from_code(
+            let parser = PyModule::from_code_bound(
                 py,
                 r#"
 from prometheus_client.openmetrics.parser import text_string_to_metric_families


### PR DESCRIPTION
Replaces https://github.com/prometheus/client_rust/pull/198.

Close #181 
Close #182 
Close #183
Close #187 