### PR TITLE
Add missing tests for some 32-bit types that already work in metrics

### DIFF
--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -709,7 +709,7 @@ mod tests {
     use crate::metrics::{counter::Counter, exemplar::CounterWithExemplar};
     use pyo3::{prelude::*, types::PyModule};
     use std::borrow::Cow;
-    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::{AtomicI32, AtomicU32};
 
     #[test]
     fn encode_counter() {
@@ -782,6 +782,9 @@ mod tests {
         registry.register("my_gauge", "My gauge", gauge);
         let gauge = Gauge::<u32, AtomicU32>::default();
         registry.register("u32_gauge", "Gauge::<u32, AtomicU32>", gauge);
+
+        let gauge_i32 = Gauge::<i32, AtomicI32>::default();
+        registry.register("i32_gauge", "Gauge::<i32, AtomicU32>", gauge_i32);
 
         let mut encoded = String::new();
 

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -717,6 +717,9 @@ mod tests {
         let mut registry = Registry::default();
         registry.register("my_counter", "My counter", counter);
 
+        let counter_u32 = Counter::<u32, AtomicU32>::default();
+        registry.register("u32_counter", "Counter::<u32, AtomicU32>", counter_u32);
+
         let mut encoded = String::new();
 
         encode(&mut encoded, &registry).unwrap();


### PR DESCRIPTION
This adds tests for the new capabilities enabled by #173.