### PR TITLE
feat: allow Arc<String> on EncodeLabelSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `i32`/`f32` for `Gauge` and `u32`/`f32` for `Counter`/`CounterWithExemplar`.
   See [PR 173] and [PR 216].
 
+- Supoort `Arc<String>` for `EncodeLabelValue`.
+  See [PR 217].
+
 [PR 173]: https://github.com/prometheus/client_rust/pull/173
 [PR 216]: https://github.com/prometheus/client_rust/pull/216
+[PR 217]: https://github.com/prometheus/client_rust/pull/217
 
 ## [0.22.3]
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -468,7 +468,14 @@ impl EncodeLabelValue for &str {
         Ok(())
     }
 }
+
 impl EncodeLabelValue for String {
+    fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
+        EncodeLabelValue::encode(&self.as_str(), encoder)
+    }
+}
+
+impl EncodeLabelValue for &String {
     fn encode(&self, encoder: &mut LabelValueEncoder) -> Result<(), std::fmt::Error> {
         EncodeLabelValue::encode(&self.as_str(), encoder)
     }


### PR DESCRIPTION
I'm writing a label struct like this:

```
#[derive(Debug, Clone, Hash, Eq, PartialEq, EncodeLabelSet)]
struct ErrorLabels {
    op: &'static str,
    scheme: &'static str,
    err: &'static str,
    root: Arc<String>,
    namespace: Arc<String>,
}
```

in this struct, the `root` and `namespace` field is nearly immutable after a client get established. i hope to use `Arc` to reduce copy Strings on updating metrics. 

but i got this error:

```
the trait bound `for<'a> &'a std::string::String: EncodeLabelValue` is not satisfied
the trait `EncodeLabelValue` is implemented for `std::string::String`
required for `Arc<std::string::String>` to implement `EncodeLabelValue`
```

it tells that we need implement &String to EncodeLabelValue.

this PR addes a implement about EncodeLabelValue for `&String`, and it can make the previous labels struct compile successfully.
