### PR TITLE
Derive macro to register struct of metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,14 @@ default = []
 protobuf = ["dep:prost", "dep:prost-types", "dep:prost-build"]
 
 [workspace]
-members = ["derive-encode"]
+members = ["derive-encode", "derive-register"]
 
 [dependencies]
 dtoa = "1.0"
 itoa = "1.0"
 parking_lot = "0.12"
 prometheus-client-derive-encode = { version = "0.4.1", path = "derive-encode" }
+prometheus-client-derive-register = { version = "0.1.0", path = "derive-register" }
 prost = { version = "0.12.0", optional = true }
 prost-types = { version = "0.12.0", optional = true }
 

--- a/derive-register/Cargo.toml
+++ b/derive-register/Cargo.toml
@@ -8,6 +8,9 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 
+[dev-dependencies]
+prometheus-client = { path = "../" }
+
 [lib]
 proc-macro = true
 

--- a/derive-register/Cargo.toml
+++ b/derive-register/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+darling = "0.20.10"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"

--- a/derive-register/Cargo.toml
+++ b/derive-register/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "prometheus-client-derive-register"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = "2"
+
+[lib]
+proc-macro = true
+

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -1,0 +1,6 @@
+use quote::quote;
+
+#[proc_macro_derive(Register)]
+pub fn derive_register(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    quote! { ::std::compile_error!("todo") }.into()
+}

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -19,6 +19,7 @@ struct RegisterField {
     attrs: Vec<syn::Attribute>,
     skip: Flag,
     unit: Option<String>,
+    name: Option<String>,
 }
 
 #[proc_macro_derive(Register, attributes(register))]
@@ -48,7 +49,11 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
 
             let ident = field.ident.unwrap();
             let ty = field.ty;
-            let name = ident.to_string();
+            let name = if let Some(name) = field.name {
+                name
+            } else {
+                ident.to_string()
+            };
 
             let unit = if let Some(unit) = field.unit {
                 quote!(Some(::prometheus_client::registry::Unit::Other(#unit.to_string())))

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -18,6 +18,7 @@ struct RegisterField {
     ty: Type,
     attrs: Vec<syn::Attribute>,
     skip: Flag,
+    unit: Option<String>,
 }
 
 #[proc_macro_derive(Register, attributes(register))]
@@ -49,12 +50,18 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
             let ty = field.ty;
             let name = ident.to_string();
 
+            let unit = if let Some(unit) = field.unit {
+                quote!(Some(::prometheus_client::registry::Unit::Other(#unit.to_string())))
+            } else {
+                quote!(None)
+            };
+
             quote! {
                 <#ty as ::prometheus_client::registry::RegisterField>::register_field(
                     &self.#ident,
                     #name,
                     #help,
-                    None,
+                    #unit,
                     registry,
                 )
             }

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -34,7 +34,7 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
 
         quote! {
             <#ty as ::prometheus_client::registry::RegisterField>::register_field(
-                self.#ident,
+                &self.#ident,
                 #name,
                 #help,
                 None,
@@ -45,14 +45,14 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
 
     quote! {
         impl #impl_generics ::prometheus_client::registry::Register for #name #ty_generics #where_clause {
-            fn register(self, registry: &mut ::prometheus_client::registry::Registry) {
-                <Self as ::prometheus_client::registry::RegisterField>::register_field(self, "", "", None, registry);
+            fn register(&self, registry: &mut ::prometheus_client::registry::Registry) {
+                <Self as ::prometheus_client::registry::RegisterField>::register_field(&self, "", "", None, registry);
             }
         }
 
         impl #impl_generics ::prometheus_client::registry::RegisterField for #name #ty_generics #where_clause {
             fn register_field<N: Into<String>, H: Into<String>>(
-                self,
+                &self,
                 name: N,
                 help: H,
                 unit: Option<::prometheus_client::registry::Unit>,

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -20,6 +20,7 @@ struct RegisterField {
     skip: Flag,
     unit: Option<String>,
     name: Option<String>,
+    help: Option<String>,
 }
 
 #[proc_macro_derive(Register, attributes(register))]
@@ -45,6 +46,10 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
                         help = doc.trim().to_string();
                     }
                 }
+            }
+
+            if let Some(custom_help) = field.help {
+                help = custom_help;
             }
 
             let ident = field.ident.unwrap();

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -51,7 +51,7 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
         }
 
         impl #impl_generics ::prometheus_client::registry::RegisterField for #name #ty_generics #where_clause {
-            fn register_field<N: Into<String>, H: Into<String>>(
+            fn register_field<N: ::std::convert::Into<::std::string::String>, H: ::std::convert::Into<::std::string::String>>(
                 &self,
                 name: N,
                 help: H,

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -46,7 +46,7 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
     quote! {
         impl #impl_generics ::prometheus_client::registry::Register for #name #ty_generics #where_clause {
             fn register(&self, registry: &mut ::prometheus_client::registry::Registry) {
-                <Self as ::prometheus_client::registry::RegisterField>::register_field(&self, "", "", None, registry);
+                #(#field_register);*
             }
         }
 
@@ -58,7 +58,9 @@ pub fn derive_register(input: TokenStream) -> TokenStream {
                 unit: Option<::prometheus_client::registry::Unit>,
                 registry: &mut ::prometheus_client::registry::Registry)
             {
-                #(#field_register);*
+                let name = name.into();
+                let mut registry = registry.sub_registry_with_prefix(name);
+                <Self as ::prometheus_client::registry::Register>::register(&self, &mut registry);
             }
         }
     }.into()

--- a/derive-register/src/lib.rs
+++ b/derive-register/src/lib.rs
@@ -1,6 +1,78 @@
+use proc_macro::TokenStream;
 use quote::quote;
+use syn::{Data, DeriveInput, Expr, Fields, Lit, Meta};
 
 #[proc_macro_derive(Register)]
-pub fn derive_register(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    quote! { ::std::compile_error!("todo") }.into()
+pub fn derive_register(input: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(input).unwrap();
+
+    let name = ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let Data::Struct(strukt) = ast.data else {
+        panic!("Register can only be derived on a struct.");
+    };
+
+    let Fields::Named(fields) = strukt.fields else {
+        panic!("Register can only be derived on a struct with named fields.");
+    };
+
+    let field_register = fields.named.into_iter().map(|field| {
+        let mut help = String::new();
+        for attr in field.attrs {
+            let path = attr.path();
+            if path.is_ident("doc") && help.is_empty() {
+                if let Some(doc) = extract_doc_comment(&attr.meta) {
+                    help = doc.trim().to_string();
+                }
+            }
+        }
+
+        let ident = field.ident.unwrap();
+        let ty = field.ty;
+        let name = ident.to_string();
+
+        quote! {
+            <#ty as ::prometheus_client::registry::RegisterField>::register_field(
+                self.#ident,
+                #name,
+                #help,
+                None,
+                registry,
+            )
+        }
+    });
+
+    quote! {
+        impl #impl_generics ::prometheus_client::registry::Register for #name #ty_generics #where_clause {
+            fn register(self, registry: &mut ::prometheus_client::registry::Registry) {
+                <Self as ::prometheus_client::registry::RegisterField>::register_field(self, "", "", None, registry);
+            }
+        }
+
+        impl #impl_generics ::prometheus_client::registry::RegisterField for #name #ty_generics #where_clause {
+            fn register_field<N: Into<String>, H: Into<String>>(
+                self,
+                name: N,
+                help: H,
+                unit: Option<::prometheus_client::registry::Unit>,
+                registry: &mut ::prometheus_client::registry::Registry)
+            {
+                #(#field_register);*
+            }
+        }
+    }.into()
+}
+
+fn extract_doc_comment(meta: &Meta) -> Option<String> {
+    let Meta::NameValue(nv) = meta else {
+        return None;
+    };
+    let Expr::Lit(lit) = &nv.value else {
+        return None;
+    };
+    let Lit::Str(lit_str) = &lit.lit else {
+        return None;
+    };
+    Some(lit_str.value())
 }

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -13,6 +13,8 @@ struct Metrics {
     skipped: Counter,
     #[register(unit = "bytes")]
     custom_unit: Counter,
+    #[register(name = "my_custom_name")]
+    custom_name: Counter,
 }
 
 #[derive(Register, Default)]
@@ -41,6 +43,9 @@ fn basic_flow() {
         + "# TYPE custom_unit_bytes counter\n"
         + "# UNIT custom_unit_bytes bytes\n"
         + "custom_unit_bytes_total 0\n"
+        + "# HELP my_custom_name .\n"
+        + "# TYPE my_custom_name counter\n"
+        + "my_custom_name_total 0\n"
         + "# HELP nested_my_gauge This is my gauge.\n"
         + "# TYPE nested_my_gauge gauge\n"
         + "nested_my_gauge 23\n"

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -1,6 +1,6 @@
 use prometheus_client::{
     encoding::text::encode,
-    metrics::counter::Counter,
+    metrics::{counter::Counter, gauge::Gauge},
     registry::{Register, RegisterDefault, Registry},
 };
 
@@ -8,6 +8,13 @@ use prometheus_client::{
 struct Metrics {
     /// This is my counter
     my_counter: Counter,
+    nested: NestedMetrics,
+}
+
+#[derive(Register, Default)]
+struct NestedMetrics {
+    /// This is my gauge
+    my_gauge: Gauge,
 }
 
 #[test]
@@ -18,6 +25,7 @@ fn basic_flow() {
     metrics.register(&mut registry);
 
     metrics.my_counter.inc();
+    metrics.nested.my_gauge.set(23);
 
     // Encode all metrics in the registry in the text format.
     let mut buffer = String::new();
@@ -26,6 +34,9 @@ fn basic_flow() {
     let expected = "# HELP my_counter This is my counter.\n".to_owned()
         + "# TYPE my_counter counter\n"
         + "my_counter_total 1\n"
+        + "# HELP nested_my_gauge This is my gauge.\n"
+        + "# TYPE nested_my_gauge gauge\n"
+        + "nested_my_gauge 23\n"
         + "# EOF\n";
     assert_eq!(expected, buffer);
 }
@@ -37,6 +48,7 @@ fn basic_flow_default() {
     let metrics = Metrics::register_default(&mut registry);
 
     metrics.my_counter.inc();
+    metrics.nested.my_gauge.set(23);
 
     // Encode all metrics in the registry in the text format.
     let mut buffer = String::new();
@@ -45,6 +57,9 @@ fn basic_flow_default() {
     let expected = "# HELP my_counter This is my counter.\n".to_owned()
         + "# TYPE my_counter counter\n"
         + "my_counter_total 1\n"
+        + "# HELP nested_my_gauge This is my gauge.\n"
+        + "# TYPE nested_my_gauge gauge\n"
+        + "nested_my_gauge 23\n"
         + "# EOF\n";
     assert_eq!(expected, buffer);
 }

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -9,6 +9,8 @@ struct Metrics {
     /// This is my counter
     my_counter: Counter,
     nested: NestedMetrics,
+    #[register(skip)]
+    skipped: Counter,
 }
 
 #[derive(Register, Default)]
@@ -19,30 +21,6 @@ struct NestedMetrics {
 
 #[test]
 fn basic_flow() {
-    let mut registry = Registry::default();
-
-    let metrics = Metrics::default();
-    metrics.register(&mut registry);
-
-    metrics.my_counter.inc();
-    metrics.nested.my_gauge.set(23);
-
-    // Encode all metrics in the registry in the text format.
-    let mut buffer = String::new();
-    encode(&mut buffer, &registry).unwrap();
-
-    let expected = "# HELP my_counter This is my counter.\n".to_owned()
-        + "# TYPE my_counter counter\n"
-        + "my_counter_total 1\n"
-        + "# HELP nested_my_gauge This is my gauge.\n"
-        + "# TYPE nested_my_gauge gauge\n"
-        + "nested_my_gauge 23\n"
-        + "# EOF\n";
-    assert_eq!(expected, buffer);
-}
-
-#[test]
-fn basic_flow_default() {
     let mut registry = Registry::default();
 
     let metrics = Metrics::register_default(&mut registry);

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -1,0 +1,31 @@
+use prometheus_client::{
+    encoding::text::encode,
+    metrics::counter::Counter,
+    registry::{Register, Registry},
+};
+
+#[derive(Register, Default, Clone)]
+struct Metrics {
+    /// This is my counter
+    my_counter: Counter,
+}
+
+#[test]
+fn basic_flow() {
+    let mut registry = Registry::default();
+
+    let metrics = Metrics::default();
+    metrics.clone().register(&mut registry);
+
+    metrics.my_counter.inc();
+
+    // Encode all metrics in the registry in the text format.
+    let mut buffer = String::new();
+    encode(&mut buffer, &registry).unwrap();
+
+    let expected = "# HELP my_counter This is my counter.\n".to_owned()
+        + "# TYPE my_counter counter\n"
+        + "my_counter_total 1\n"
+        + "# EOF\n";
+    assert_eq!(expected, buffer);
+}

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -1,7 +1,7 @@
 use prometheus_client::{
     encoding::text::encode,
     metrics::counter::Counter,
-    registry::{Register, Registry},
+    registry::{Register, RegisterDefault, Registry},
 };
 
 #[derive(Register, Default)]
@@ -16,6 +16,25 @@ fn basic_flow() {
 
     let metrics = Metrics::default();
     metrics.register(&mut registry);
+
+    metrics.my_counter.inc();
+
+    // Encode all metrics in the registry in the text format.
+    let mut buffer = String::new();
+    encode(&mut buffer, &registry).unwrap();
+
+    let expected = "# HELP my_counter This is my counter.\n".to_owned()
+        + "# TYPE my_counter counter\n"
+        + "my_counter_total 1\n"
+        + "# EOF\n";
+    assert_eq!(expected, buffer);
+}
+
+#[test]
+fn basic_flow_default() {
+    let mut registry = Registry::default();
+
+    let metrics = Metrics::register_default(&mut registry);
 
     metrics.my_counter.inc();
 

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -4,7 +4,7 @@ use prometheus_client::{
     registry::{Register, Registry},
 };
 
-#[derive(Register, Default, Clone)]
+#[derive(Register, Default)]
 struct Metrics {
     /// This is my counter
     my_counter: Counter,
@@ -15,7 +15,7 @@ fn basic_flow() {
     let mut registry = Registry::default();
 
     let metrics = Metrics::default();
-    metrics.clone().register(&mut registry);
+    metrics.register(&mut registry);
 
     metrics.my_counter.inc();
 

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -15,6 +15,9 @@ struct Metrics {
     custom_unit: Counter,
     #[register(name = "my_custom_name")]
     custom_name: Counter,
+    /// This will get ignored
+    #[register(help = "my custom help")]
+    custom_help: Counter,
 }
 
 #[derive(Register, Default)]
@@ -46,6 +49,9 @@ fn basic_flow() {
         + "# HELP my_custom_name .\n"
         + "# TYPE my_custom_name counter\n"
         + "my_custom_name_total 0\n"
+        + "# HELP custom_help my custom help.\n"
+        + "# TYPE custom_help counter\n"
+        + "custom_help_total 0\n"
         + "# HELP nested_my_gauge This is my gauge.\n"
         + "# TYPE nested_my_gauge gauge\n"
         + "nested_my_gauge 23\n"

--- a/derive-register/tests/lib.rs
+++ b/derive-register/tests/lib.rs
@@ -11,6 +11,8 @@ struct Metrics {
     nested: NestedMetrics,
     #[register(skip)]
     skipped: Counter,
+    #[register(unit = "bytes")]
+    custom_unit: Counter,
 }
 
 #[derive(Register, Default)]
@@ -35,6 +37,10 @@ fn basic_flow() {
     let expected = "# HELP my_counter This is my counter.\n".to_owned()
         + "# TYPE my_counter counter\n"
         + "my_counter_total 1\n"
+        + "# HELP custom_unit_bytes .\n"
+        + "# TYPE custom_unit_bytes counter\n"
+        + "# UNIT custom_unit_bytes bytes\n"
+        + "custom_unit_bytes_total 0\n"
         + "# HELP nested_my_gauge This is my gauge.\n"
         + "# TYPE nested_my_gauge gauge\n"
         + "nested_my_gauge 23\n"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -389,3 +389,33 @@ pub trait Metric: crate::encoding::EncodeMetric + Send + Sync + std::fmt::Debug 
 
 impl<T> Metric for T where T: crate::encoding::EncodeMetric + Send + Sync + std::fmt::Debug + 'static
 {}
+
+pub trait Register {
+    fn register(self, registry: &mut Registry);
+}
+
+pub trait RegisterField {
+    fn register_field<N: Into<String>, H: Into<String>>(
+        self,
+        name: N,
+        help: H,
+        unit: Option<Unit>,
+        registry: &mut Registry,
+    );
+}
+
+impl<T: Metric> RegisterField for T {
+    fn register_field<N: Into<String>, H: Into<String>>(
+        self,
+        name: N,
+        help: H,
+        unit: Option<Unit>,
+        registry: &mut Registry,
+    ) {
+        if let Some(unit) = unit {
+            registry.register_with_unit(name, help, unit, metric)
+        } else {
+            registry.register(name, help, metric)
+        }
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -415,9 +415,9 @@ impl<T: Metric> RegisterField for T {
         registry: &mut Registry,
     ) {
         if let Some(unit) = unit {
-            registry.register_with_unit(name, help, unit, metric)
+            registry.register_with_unit(name, help, unit, self)
         } else {
-            registry.register(name, help, metric)
+            registry.register(name, help, self)
         }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,6 +2,8 @@
 //!
 //! See [`Registry`] for details.
 
+pub use prometheus_client_derive_register::*;
+
 use std::borrow::Cow;
 
 use crate::collector::Collector;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -396,6 +396,21 @@ pub trait Register {
     fn register(&self, registry: &mut Registry);
 }
 
+pub trait RegisterDefault {
+    fn register_default(registry: &mut Registry) -> Self;
+}
+
+impl<T> RegisterDefault for T
+where
+    T: Register + Default,
+{
+    fn register_default(registry: &mut Registry) -> Self {
+        let this = Self::default();
+        this.register(registry);
+        this
+    }
+}
+
 pub trait RegisterField {
     fn register_field<N: Into<String>, H: Into<String>>(
         &self,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -393,12 +393,12 @@ impl<T> Metric for T where T: crate::encoding::EncodeMetric + Send + Sync + std:
 {}
 
 pub trait Register {
-    fn register(self, registry: &mut Registry);
+    fn register(&self, registry: &mut Registry);
 }
 
 pub trait RegisterField {
     fn register_field<N: Into<String>, H: Into<String>>(
-        self,
+        &self,
         name: N,
         help: H,
         unit: Option<Unit>,
@@ -406,18 +406,21 @@ pub trait RegisterField {
     );
 }
 
-impl<T: Metric> RegisterField for T {
+impl<T> RegisterField for T
+where
+    T: Metric + Clone,
+{
     fn register_field<N: Into<String>, H: Into<String>>(
-        self,
+        &self,
         name: N,
         help: H,
         unit: Option<Unit>,
         registry: &mut Registry,
     ) {
         if let Some(unit) = unit {
-            registry.register_with_unit(name, help, unit, self)
+            registry.register_with_unit(name, help, unit, self.clone())
         } else {
-            registry.register(name, help, self)
+            registry.register(name, help, self.clone())
         }
     }
 }


### PR DESCRIPTION
Resolves #140 
cc @mxinden 

Here is a rough implementation. It does not have docs yet

Example:
```rust
#[derive(Register, Default)]
struct Metrics {
    /// This is my counter
    my_counter: Counter,
    nested: NestedMetrics,
    #[register(skip)]
    skipped: Counter,
    #[register(unit = "bytes")]
    custom_unit: Counter,
    #[register(name = "my_custom_name")]
    custom_name: Counter,
    /// This will get ignored
    #[register(help = "my custom help")]
    custom_help: Counter,
}

#[derive(Register, Default)]
struct NestedMetrics {
    /// This is my gauge
    my_gauge: Gauge,
}
```

```rust
// Only if Metrics implements default
let metrics = Metrics::register_default(&mut registry);

let metrics = Metrics::default();
metrics.register(&mut registry);
```