### PR TITLE
fix(encoding): correctly handle empty family labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR 216]: https://github.com/prometheus/client_rust/pull/216
 [PR 217]: https://github.com/prometheus/client_rust/pull/217
 
+### Fixed
+
+- Don't prepend `,` when encoding empty family label set.
+  See [PR 175].
+
+[PR 175]: https://github.com/prometheus/client_rust/pull/175
+
 ## [0.22.3]
 
 ### Added

--- a/examples/custom-metric.rs
+++ b/examples/custom-metric.rs
@@ -1,4 +1,4 @@
-use prometheus_client::encoding::{text::encode, EncodeMetric, MetricEncoder};
+use prometheus_client::encoding::{text::encode, EncodeMetric, MetricEncoder, NoLabelSet};
 use prometheus_client::metrics::MetricType;
 use prometheus_client::registry::Registry;
 
@@ -20,7 +20,7 @@ impl EncodeMetric for MyCustomMetric {
         // E.g. every CPU cycle spend in this method delays the response send to
         // the Prometheus server.
 
-        encoder.encode_counter::<(), _, u64>(&rand::random::<u64>(), None)
+        encoder.encode_counter::<NoLabelSet, _, u64>(&rand::random::<u64>(), None)
     }
 
     fn metric_type(&self) -> prometheus_client::metrics::MetricType {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -247,6 +247,9 @@ pub trait EncodeLabel {
 #[derive(Debug)]
 pub struct LabelEncoder<'a>(LabelEncoderInner<'a>);
 
+/// Uninhabited type to represent the lack of a label set for a metric
+pub(crate) enum NoLabelSet {}
+
 #[derive(Debug)]
 enum LabelEncoderInner<'a> {
     Text(text::LabelEncoder<'a>),
@@ -352,7 +355,7 @@ impl<T: EncodeLabel> EncodeLabelSet for Vec<T> {
     }
 }
 
-impl EncodeLabelSet for () {
+impl EncodeLabelSet for NoLabelSet {
     fn encode(&self, _encoder: LabelSetEncoder) -> Result<(), std::fmt::Error> {
         Ok(())
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -248,7 +248,8 @@ pub trait EncodeLabel {
 pub struct LabelEncoder<'a>(LabelEncoderInner<'a>);
 
 /// Uninhabited type to represent the lack of a label set for a metric
-pub(crate) enum NoLabelSet {}
+#[derive(Debug)]
+pub enum NoLabelSet {}
 
 #[derive(Debug)]
 enum LabelEncoderInner<'a> {

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -734,8 +734,8 @@ mod tests {
     use crate::metrics::{counter::Counter, exemplar::CounterWithExemplar};
     use pyo3::{prelude::*, types::PyModule};
     use std::borrow::Cow;
-    use std::sync::atomic::{AtomicI32, AtomicU32};
     use std::fmt::Error;
+    use std::sync::atomic::{AtomicI32, AtomicU32};
 
     #[test]
     fn encode_counter() {

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`Counter`] for details.
 
-use crate::encoding::{EncodeMetric, MetricEncoder};
+use crate::encoding::{EncodeMetric, MetricEncoder, NoLabelSet};
 
 use super::{MetricType, TypedMetric};
 use std::marker::PhantomData;
@@ -204,7 +204,7 @@ where
     A: Atomic<N>,
 {
     fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
-        encoder.encode_counter::<(), _, u64>(&self.get(), None)
+        encoder.encode_counter::<NoLabelSet, _, u64>(&self.get(), None)
     }
 
     fn metric_type(&self) -> MetricType {
@@ -236,7 +236,7 @@ where
     N: crate::encoding::EncodeCounterValue,
 {
     fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
-        encoder.encode_counter::<(), _, u64>(&self.value, None)
+        encoder.encode_counter::<NoLabelSet, _, u64>(&self.value, None)
     }
 
     fn metric_type(&self) -> MetricType {

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`Histogram`] for details.
 
-use crate::encoding::{EncodeMetric, MetricEncoder};
+use crate::encoding::{EncodeMetric, MetricEncoder, NoLabelSet};
 
 use super::{MetricType, TypedMetric};
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
@@ -133,7 +133,7 @@ pub fn linear_buckets(start: f64, width: f64, length: u16) -> impl Iterator<Item
 impl EncodeMetric for Histogram {
     fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
         let (sum, count, buckets) = self.get();
-        encoder.encode_histogram::<()>(sum, count, &buckets, None)
+        encoder.encode_histogram::<NoLabelSet>(sum, count, &buckets, None)
     }
 
     fn metric_type(&self) -> MetricType {


### PR DESCRIPTION
Replaces https://github.com/prometheus/client_rust/pull/175.