### PR TITLE
Implement Atomic<u64> for AtomicU64 for gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.23.0] - unreleased
 
-- Implement `Atomic<u64>` for `AtomicU64` for gauges.
-  See [PR 226].
-
-[PR 226]: https://github.com/prometheus/client_rust/pull/198
 
 ### Changed
 
@@ -19,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `prost` dependencies to `v0.12`.
   See [PR 198].
 
+- Implement `Atomic<u64>` for `AtomicU64` for gauges.
+  See [PR 226].
+
+[PR 226]: https://github.com/prometheus/client_rust/pull/198
 [PR 198]: https://github.com/prometheus/client_rust/pull/198
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.23.0] - unreleased
 
+- Implement `Atomic<u64>` for `AtomicU64` for gauges.
+  See [PR 226].
+
+[PR 226]: https://github.com/prometheus/client_rust/pull/198
+
 ### Changed
 
 - `ConstCounter::new` now requires specifying the type of literal arguments, like this: `ConstCounter::new(42u64);`.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -568,6 +568,19 @@ impl EncodeGaugeValue for i64 {
     }
 }
 
+impl EncodeGaugeValue for u64 {
+    fn encode(&self, encoder: &mut GaugeValueEncoder) -> Result<(), std::fmt::Error> {
+        // Between forcing end users to do endless as i64 for things that are
+        // clearly u64 and having one error case for rarely used protobuf when
+        // a gauge is set to u64::MAX, the latter seems like the right choice.
+        if *self == u64::MAX {
+            return Err(std::fmt::Error);
+        }
+
+        encoder.encode_i64(*self as i64)
+    }
+}
+
 impl EncodeGaugeValue for f64 {
     fn encode(&self, encoder: &mut GaugeValueEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode_f64(*self)

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -214,6 +214,33 @@ impl Atomic<i64> for AtomicI64 {
 }
 
 #[cfg(target_has_atomic = "64")]
+impl Atomic<u64> for AtomicU64 {
+    fn inc(&self) -> u64 {
+        self.inc_by(1)
+    }
+
+    fn inc_by(&self, v: u64) -> u64 {
+        self.fetch_add(v, Ordering::Relaxed)
+    }
+
+    fn dec(&self) -> u64 {
+        self.dec_by(1)
+    }
+
+    fn dec_by(&self, v: u64) -> u64 {
+        self.fetch_sub(v, Ordering::Relaxed)
+    }
+
+    fn set(&self, v: u64) -> u64 {
+        self.swap(v, Ordering::Relaxed)
+    }
+
+    fn get(&self) -> u64 {
+        self.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(target_has_atomic = "64")]
 impl Atomic<f64> for AtomicU64 {
     fn inc(&self) -> f64 {
         self.inc_by(1.0)


### PR DESCRIPTION
Between forcing end users to do endless `as i64` for things that are clearly `u64` and having one error case for rarely used protobuf when a gauge is set to `u64::MAX`, the latter seems like the right choice.