### PR TITLE
refactor(registry): improve constructors of Registry

### DIFF
--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -24,7 +24,7 @@ use tokio::{
 async fn main() {
     let request_counter: Counter<u64> = Default::default();
 
-    let mut registry = <Registry>::with_prefix("tokio_hyper_example");
+    let mut registry = Registry::default().with_prefix("tokio_hyper_example");
 
     registry.register(
         "requests",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! //
 //! // Note the angle brackets to make sure to use the default (dynamic
 //! // dispatched boxed metric) for the generic type parameter.
-//! let mut registry = <Registry>::default();
+//! let mut registry = Registry::default();
 //!
 //! // Define a type representing a metric label set, i.e. a key value pair.
 //! //
@@ -37,13 +37,13 @@
 //!   method: Method,
 //!   // Or just a plain string.
 //!   path: String,
-//! };
+//! }
 //!
 //! #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
 //! enum Method {
 //!   GET,
 //!   PUT,
-//! };
+//! }
 //!
 //! // Create a sample counter metric family utilizing the above custom label
 //! // type, representing the number of HTTP requests received.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -67,34 +67,19 @@ pub struct Registry {
 }
 
 impl Registry {
-    /// Creates a new default [`Registry`] with the given prefix.
-    pub fn with_prefix(prefix: impl Into<String>) -> Self {
-        Self {
-            prefix: Some(Prefix(prefix.into())),
-            ..Default::default()
-        }
+    /// Sets the prefix of the [`Registry`].
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(Prefix(prefix.into()));
+        self
     }
 
-    /// Creates a new default [`Registry`] with the given labels.
+    /// Sets the labels of the [`Registry`].
     pub fn with_labels(
+        mut self,
         labels: impl Iterator<Item = (Cow<'static, str>, Cow<'static, str>)>,
     ) -> Self {
-        Self {
-            labels: labels.into_iter().collect(),
-            ..Default::default()
-        }
-    }
-
-    /// Creates a new default [`Registry`] with the given prefix and labels.
-    pub fn with_prefix_and_labels(
-        prefix: impl Into<String>,
-        labels: impl Iterator<Item = (Cow<'static, str>, Cow<'static, str>)>,
-    ) -> Self {
-        Self {
-            prefix: Some(Prefix(prefix.into())),
-            labels: labels.into_iter().collect(),
-            ..Default::default()
-        }
+        self.labels = labels.into_iter().collect();
+        self
     }
 
     /// Register a metric with the [`Registry`].
@@ -242,13 +227,11 @@ impl Registry {
     /// See [`Registry::sub_registry_with_label`] for the same functionality,
     /// but namespacing with a label instead of a metric name prefix.
     pub fn sub_registry_with_prefix<P: AsRef<str>>(&mut self, prefix: P) -> &mut Self {
-        let sub_registry = Registry {
-            prefix: Some(Prefix(
+        let sub_registry = Registry::default()
+            .with_prefix(
                 self.prefix.clone().map(|p| p.0 + "_").unwrap_or_default() + prefix.as_ref(),
-            )),
-            labels: self.labels.clone(),
-            ..Default::default()
-        };
+            )
+            .with_labels(self.labels.clone().into_iter());
 
         self.priv_sub_registry(sub_registry)
     }


### PR DESCRIPTION
The current APIs of `Registry` does not allow me to change the `prefix` and `labels` of a `Registry` after it's constructed.

**Breaking Changes**:

- change `fn with_prefix(prefix: ...) -> Self` => `fn with_prefix(mut self, prefix: ...) -> Self`
- change `fn with_labels(labels: ...) -> Self` => `fn with_labels(mut self, labels: ...) -> Self`
- remove `fn with_prefix_and_labels(prefix: ..., labels: ...) -> Self`