### PR TITLE
feat(encoding)!: 🧁 encoding traits do not consume encoders

### DIFF
--- a/derive-encode/src/lib.rs
+++ b/derive-encode/src/lib.rs
@@ -72,7 +72,7 @@ pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
 
     let gen = quote! {
         impl prometheus_client::encoding::EncodeLabelSet for #name {
-            fn encode(&self, mut encoder: prometheus_client::encoding::LabelSetEncoder) -> std::result::Result<(), std::fmt::Error> {
+            fn encode(&self, encoder: &mut prometheus_client::encoding::LabelSetEncoder) -> std::result::Result<(), std::fmt::Error> {
                 use prometheus_client::encoding::EncodeLabel;
                 use prometheus_client::encoding::EncodeLabelKey;
                 use prometheus_client::encoding::EncodeLabelValue;

--- a/examples/custom-metric.rs
+++ b/examples/custom-metric.rs
@@ -11,7 +11,7 @@ use prometheus_client::registry::Registry;
 struct MyCustomMetric {}
 
 impl EncodeMetric for MyCustomMetric {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         // This method is called on each Prometheus server scrape. Allowing you
         // to execute whatever logic is needed to generate and encode your
         // custom metric.

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -22,20 +22,20 @@ use crate::encoding::DescriptorEncoder;
 /// struct MyCollector {}
 ///
 /// impl Collector for MyCollector {
-///     fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+///     fn encode(&self, encoder: &mut DescriptorEncoder) -> Result<(), std::fmt::Error> {
 ///         let counter = ConstCounter::new(42u64);
-///         let metric_encoder = encoder.encode_descriptor(
+///         let mut metric_encoder = encoder.encode_descriptor(
 ///             "my_counter",
 ///             "some help",
 ///             None,
 ///             counter.metric_type(),
 ///         )?;
-///         counter.encode(metric_encoder)?;
+///         counter.encode(&mut metric_encoder)?;
 ///         Ok(())
 ///     }
 /// }
 /// ```
 pub trait Collector: std::fmt::Debug + Send + Sync + 'static {
     /// Once the [`Collector`] is registered, this method is called on each scrape.
-    fn encode(&self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error>;
+    fn encode(&self, encoder: &mut DescriptorEncoder) -> Result<(), std::fmt::Error>;
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -691,29 +691,29 @@ impl<'a> CounterValueEncoder<'a> {
 /// An encodable exemplar value.
 pub trait EncodeExemplarValue {
     /// Encode the given instance in the OpenMetrics text encoding.
-    fn encode(&self, encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error>;
+    fn encode(&self, encoder: &mut ExemplarValueEncoder) -> Result<(), std::fmt::Error>;
 }
 
 impl EncodeExemplarValue for f64 {
-    fn encode(&self, mut encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode(*self)
     }
 }
 
 impl EncodeExemplarValue for u64 {
-    fn encode(&self, mut encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode(*self as f64)
     }
 }
 
 impl EncodeExemplarValue for f32 {
-    fn encode(&self, mut encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode(*self as f64)
     }
 }
 
 impl EncodeExemplarValue for u32 {
-    fn encode(&self, mut encoder: ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut ExemplarValueEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode(*self as f64)
     }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -43,7 +43,7 @@ macro_rules! for_both {
 pub trait EncodeMetric {
     /// Encode the given instance in the OpenMetrics text encoding.
     // TODO: Lifetimes on MetricEncoder needed?
-    fn encode(&self, encoder: MetricEncoder) -> Result<(), std::fmt::Error>;
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error>;
 
     /// The OpenMetrics metric type of the instance.
     // One can not use [`TypedMetric`] directly, as associated constants are not
@@ -52,7 +52,7 @@ pub trait EncodeMetric {
 }
 
 impl EncodeMetric for Box<dyn EncodeMetric> {
-    fn encode(&self, encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         self.deref().encode(encoder)
     }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -240,7 +240,7 @@ impl<'a> LabelSetEncoder<'a> {
 /// An encodable label.
 pub trait EncodeLabel {
     /// Encode oneself into the given encoder.
-    fn encode(&self, encoder: LabelEncoder) -> Result<(), std::fmt::Error>;
+    fn encode(&self, encoder: &mut LabelEncoder) -> Result<(), std::fmt::Error>;
 }
 
 /// Encoder for a label.
@@ -343,7 +343,7 @@ impl<T: EncodeLabel> EncodeLabelSet for &[T] {
         }
 
         for label in self.iter() {
-            label.encode(encoder.encode_label())?
+            label.encode(&mut encoder.encode_label())?
         }
 
         Ok(())
@@ -363,7 +363,7 @@ impl EncodeLabelSet for NoLabelSet {
 }
 
 impl<K: EncodeLabelKey, V: EncodeLabelValue> EncodeLabel for (K, V) {
-    fn encode(&self, mut encoder: LabelEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut LabelEncoder) -> Result<(), std::fmt::Error> {
         let (key, value) = self;
 
         let mut label_key_encoder = encoder.encode_label_key()?;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -203,7 +203,7 @@ impl MetricEncoder<'_> {
 /// An encodable label set.
 pub trait EncodeLabelSet {
     /// Encode oneself into the given encoder.
-    fn encode(&self, encoder: LabelSetEncoder) -> Result<(), std::fmt::Error>;
+    fn encode(&self, encoder: &mut LabelSetEncoder) -> Result<(), std::fmt::Error>;
 }
 
 impl<'a> From<text::LabelSetEncoder<'a>> for LabelSetEncoder<'a> {
@@ -331,13 +331,13 @@ impl<'a> LabelKeyEncoder<'a> {
     }
 }
 impl<T: EncodeLabel, const N: usize> EncodeLabelSet for [T; N] {
-    fn encode(&self, encoder: LabelSetEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut LabelSetEncoder) -> Result<(), std::fmt::Error> {
         self.as_ref().encode(encoder)
     }
 }
 
 impl<T: EncodeLabel> EncodeLabelSet for &[T] {
-    fn encode(&self, mut encoder: LabelSetEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut LabelSetEncoder) -> Result<(), std::fmt::Error> {
         if self.is_empty() {
             return Ok(());
         }
@@ -351,13 +351,13 @@ impl<T: EncodeLabel> EncodeLabelSet for &[T] {
 }
 
 impl<T: EncodeLabel> EncodeLabelSet for Vec<T> {
-    fn encode(&self, encoder: LabelSetEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut LabelSetEncoder) -> Result<(), std::fmt::Error> {
         self.as_slice().encode(encoder)
     }
 }
 
 impl EncodeLabelSet for NoLabelSet {
-    fn encode(&self, _encoder: LabelSetEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, _encoder: &mut LabelSetEncoder) -> Result<(), std::fmt::Error> {
         Ok(())
     }
 }

--- a/src/encoding/protobuf.rs
+++ b/src/encoding/protobuf.rs
@@ -294,9 +294,8 @@ impl<S: EncodeLabelSet, V: EncodeExemplarValue> TryFrom<&Exemplar<S, V>>
 
     fn try_from(exemplar: &Exemplar<S, V>) -> Result<Self, Self::Error> {
         let mut value = f64::default();
-        exemplar
-            .value
-            .encode(ExemplarValueEncoder { value: &mut value }.into())?;
+        let mut encoder = ExemplarValueEncoder { value: &mut value }.into();
+        exemplar.value.encode(&mut encoder)?;
 
         let mut labels = vec![];
         let mut encoder = LabelSetEncoder {

--- a/src/encoding/protobuf.rs
+++ b/src/encoding/protobuf.rs
@@ -119,12 +119,11 @@ impl DescriptorEncoder<'_> {
             ..Default::default()
         };
         let mut labels = vec![];
-        self.labels.encode(
-            LabelSetEncoder {
-                labels: &mut labels,
-            }
-            .into(),
-        )?;
+        let mut encoder = LabelSetEncoder {
+            labels: &mut labels,
+        }
+        .into();
+        self.labels.encode(&mut encoder)?;
         self.metric_families.push(family);
 
         Ok(MetricEncoder {
@@ -209,12 +208,11 @@ impl MetricEncoder<'_> {
         label_set: &impl super::EncodeLabelSet,
     ) -> Result<(), std::fmt::Error> {
         let mut info_labels = vec![];
-        label_set.encode(
-            LabelSetEncoder {
-                labels: &mut info_labels,
-            }
-            .into(),
-        )?;
+        let mut encoder = LabelSetEncoder {
+            labels: &mut info_labels,
+        }
+        .into();
+        label_set.encode(&mut encoder)?;
 
         self.family.push(openmetrics_data_model::Metric {
             labels: self.labels.clone(),
@@ -234,12 +232,11 @@ impl MetricEncoder<'_> {
         label_set: &S,
     ) -> Result<MetricEncoder, std::fmt::Error> {
         let mut labels = self.labels.clone();
-        label_set.encode(
-            LabelSetEncoder {
-                labels: &mut labels,
-            }
-            .into(),
-        )?;
+        let mut encoder = LabelSetEncoder {
+            labels: &mut labels,
+        }
+        .into();
+        label_set.encode(&mut encoder)?;
 
         Ok(MetricEncoder {
             metric_type: self.metric_type,
@@ -302,12 +299,11 @@ impl<S: EncodeLabelSet, V: EncodeExemplarValue> TryFrom<&Exemplar<S, V>>
             .encode(ExemplarValueEncoder { value: &mut value }.into())?;
 
         let mut labels = vec![];
-        exemplar.label_set.encode(
-            LabelSetEncoder {
-                labels: &mut labels,
-            }
-            .into(),
-        )?;
+        let mut encoder = LabelSetEncoder {
+            labels: &mut labels,
+        }
+        .into();
+        exemplar.label_set.encode(&mut encoder)?;
 
         Ok(openmetrics_data_model::Exemplar {
             value,

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -1077,7 +1077,7 @@ mod tests {
         impl crate::collector::Collector for Collector {
             fn encode(
                 &self,
-                mut encoder: crate::encoding::DescriptorEncoder,
+                encoder: &mut crate::encoding::DescriptorEncoder,
             ) -> Result<(), std::fmt::Error> {
                 let counter = crate::metrics::counter::ConstCounter::new(42u64);
                 let mut metric_encoder = encoder.encode_descriptor(

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -1080,13 +1080,13 @@ mod tests {
                 mut encoder: crate::encoding::DescriptorEncoder,
             ) -> Result<(), std::fmt::Error> {
                 let counter = crate::metrics::counter::ConstCounter::new(42u64);
-                let metric_encoder = encoder.encode_descriptor(
+                let mut metric_encoder = encoder.encode_descriptor(
                     &self.name,
                     "some help",
                     None,
                     counter.metric_type(),
                 )?;
-                counter.encode(metric_encoder)?;
+                counter.encode(&mut metric_encoder)?;
                 Ok(())
             }
         }

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -455,7 +455,7 @@ impl<'a> MetricEncoder<'a> {
             .encode(&mut LabelSetEncoder::new(self.writer).into())?;
         self.writer.write_str("} ")?;
         exemplar.value.encode(
-            ExemplarValueEncoder {
+            &mut ExemplarValueEncoder {
                 writer: self.writer,
             }
             .into(),

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -297,7 +297,8 @@ impl<'a> std::fmt::Debug for MetricEncoder<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut labels = String::new();
         if let Some(l) = self.family_labels {
-            l.encode(LabelSetEncoder::new(&mut labels).into())?;
+            let mut encoder = LabelSetEncoder::new(&mut labels).into();
+            l.encode(&mut encoder)?;
         }
 
         f.debug_struct("Encoder")
@@ -451,7 +452,7 @@ impl<'a> MetricEncoder<'a> {
         self.writer.write_str(" # {")?;
         exemplar
             .label_set
-            .encode(LabelSetEncoder::new(self.writer).into())?;
+            .encode(&mut LabelSetEncoder::new(self.writer).into())?;
         self.writer.write_str("} ")?;
         exemplar.value.encode(
             ExemplarValueEncoder {
@@ -502,14 +503,15 @@ impl<'a> MetricEncoder<'a> {
         self.writer.write_str("{")?;
 
         self.const_labels
-            .encode(LabelSetEncoder::new(self.writer).into())?;
+            .encode(&mut LabelSetEncoder::new(self.writer).into())?;
 
         if let Some(additional_labels) = additional_labels {
             if !self.const_labels.is_empty() {
                 self.writer.write_str(",")?;
             }
 
-            additional_labels.encode(LabelSetEncoder::new(self.writer).into())?;
+            let mut encoder = LabelSetEncoder::new(self.writer).into();
+            additional_labels.encode(&mut encoder)?;
         }
 
         /// Writer impl which prepends a comma on the first call to write output to the wrapped writer
@@ -539,9 +541,11 @@ impl<'a> MetricEncoder<'a> {
                     writer: self.writer,
                     should_prepend: true,
                 };
-                labels.encode(LabelSetEncoder::new(&mut writer).into())?;
+                let mut encoder = LabelSetEncoder::new(&mut writer).into();
+                labels.encode(&mut encoder)?;
             } else {
-                labels.encode(LabelSetEncoder::new(self.writer).into())?;
+                let mut encoder = LabelSetEncoder::new(self.writer).into();
+                labels.encode(&mut encoder)?;
             };
         }
 
@@ -936,7 +940,7 @@ mod tests {
         struct EmptyLabels {}
 
         impl EncodeLabelSet for EmptyLabels {
-            fn encode(&self, _encoder: crate::encoding::LabelSetEncoder) -> Result<(), Error> {
+            fn encode(&self, _encoder: &mut crate::encoding::LabelSetEncoder) -> Result<(), Error> {
                 Ok(())
             }
         }

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -203,7 +203,7 @@ where
     N: crate::encoding::EncodeCounterValue,
     A: Atomic<N>,
 {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode_counter::<NoLabelSet, _, u64>(&self.get(), None)
     }
 
@@ -235,7 +235,7 @@ impl<N> EncodeMetric for ConstCounter<N>
 where
     N: crate::encoding::EncodeCounterValue,
 {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode_counter::<NoLabelSet, _, u64>(&self.value, None)
     }
 

--- a/src/metrics/exemplar.rs
+++ b/src/metrics/exemplar.rs
@@ -155,7 +155,7 @@ where
     N: EncodeCounterValue + EncodeExemplarValue + Clone,
     A: counter::Atomic<N>,
 {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         let (value, exemplar) = self.get();
         encoder.encode_counter(&value, exemplar.as_ref())
     }
@@ -267,7 +267,7 @@ impl<S> HistogramWithExemplars<S> {
 }
 
 impl<S: EncodeLabelSet> EncodeMetric for HistogramWithExemplars<S> {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         let inner = self.inner();
         let (sum, count, buckets) = inner.histogram.get();
         encoder.encode_histogram(sum, count, &buckets, Some(&inner.exemplars))

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -312,11 +312,11 @@ where
     M: EncodeMetric + TypedMetric,
     C: MetricConstructor<M>,
 {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         let guard = self.read();
         for (label_set, m) in guard.iter() {
-            let encoder = encoder.encode_family(label_set)?;
-            m.encode(encoder)?;
+            let mut encoder = encoder.encode_family(label_set)?;
+            m.encode(&mut encoder)?;
         }
         Ok(())
     }

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -346,7 +346,7 @@ where
     N: EncodeGaugeValue,
     A: Atomic<N>,
 {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode_gauge(&self.get())
     }
     fn metric_type(&self) -> MetricType {
@@ -377,7 +377,7 @@ impl<N> EncodeMetric for ConstGauge<N>
 where
     N: EncodeGaugeValue,
 {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode_gauge(&self.value)
     }
 

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -131,7 +131,7 @@ pub fn linear_buckets(start: f64, width: f64, length: u16) -> impl Iterator<Item
 }
 
 impl EncodeMetric for Histogram {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         let (sum, count, buckets) = self.get();
         encoder.encode_histogram::<NoLabelSet>(sum, count, &buckets, None)
     }

--- a/src/metrics/info.rs
+++ b/src/metrics/info.rs
@@ -33,7 +33,7 @@ impl<S> EncodeMetric for Info<S>
 where
     S: Clone + std::hash::Hash + Eq + EncodeLabelSet,
 {
-    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut MetricEncoder) -> Result<(), std::fmt::Error> {
         encoder.encode_info(&self.0)
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -184,15 +184,15 @@ impl Registry {
     /// struct MyCollector {}
     ///
     /// impl Collector for MyCollector {
-    ///     fn encode(&self, mut encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+    ///     fn encode(&self, encoder: &mut DescriptorEncoder) -> Result<(), std::fmt::Error> {
     ///         let counter = ConstCounter::new(42u64);
-    ///         let metric_encoder = encoder.encode_descriptor(
+    ///         let mut metric_encoder = encoder.encode_descriptor(
     ///             "my_counter",
     ///             "some help",
     ///             None,
     ///             counter.metric_type(),
     ///         )?;
-    ///         counter.encode(metric_encoder)?;
+    ///         counter.encode(&mut metric_encoder)?;
     ///         Ok(())
     ///     }
     /// }
@@ -300,9 +300,9 @@ impl Registry {
         }
 
         for collector in self.collectors.iter() {
-            let descriptor_encoder =
+            let mut descriptor_encoder =
                 encoder.with_prefix_and_labels(self.prefix.as_ref(), &self.labels);
-            collector.encode(descriptor_encoder)?;
+            collector.encode(&mut descriptor_encoder)?;
         }
 
         for registry in self.sub_registries.iter() {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -290,13 +290,13 @@ impl Registry {
         for (descriptor, metric) in self.metrics.iter() {
             let mut descriptor_encoder =
                 encoder.with_prefix_and_labels(self.prefix.as_ref(), &self.labels);
-            let metric_encoder = descriptor_encoder.encode_descriptor(
+            let mut metric_encoder = descriptor_encoder.encode_descriptor(
                 &descriptor.name,
                 &descriptor.help,
                 descriptor.unit.as_ref(),
                 EncodeMetric::metric_type(metric.as_ref()),
             )?;
-            metric.encode(metric_encoder)?;
+            metric.encode(&mut metric_encoder)?;
         }
 
         for collector in self.collectors.iter() {


### PR DESCRIPTION
fixes #135.

this branch updates parameter types for different encoding traits: `EncodeLabel`, `EncodeLabelSet`, `EncodeMetric`, `Collector`, and `EncodeExemplarValue`. rather than taking ownership of their respective encoder parameters, these now accept a `&mut` mutable reference.

this allows for consumers of this API to e.g. compose label sets, loosens restrictions on field order in `#[derive(EncodeLabelSet)]` structs, and provides a consistent signature type by following the pattern already set by `EncodeLabelKey`, `EncodeLabelValue`, `EncodeGaugeValue`, and other existing encoding traits.