### PR TITLE
refactor(metrics/histogram): 🎂 constructor accepts `IntoIterator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.0] - unreleased
+## [0.23.1] - unreleased
+
+### Changed
 
 - `Histogram::new` now accepts an `IntoIterator` argument, rather than an `Iterator`.
   See [PR 243].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - unreleased
+
+- `Histogram::new` now accepts an `IntoIterator` argument, rather than an `Iterator`.
+  See [PR 243].
+
+[PR 243]: https://github.com/prometheus/client_rust/pull/243
+
 ## [0.23.0]
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-client"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["Max Inden <mail@max-inden.de>"]
 edition = "2021"
 description = "Open Metrics client library allowing users to natively instrument applications."

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 /// let custom_buckets = [
 ///    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 /// ];
-/// let histogram = Histogram::new(custom_buckets.into_iter());
+/// let histogram = Histogram::new(custom_buckets);
 /// histogram.observe(4.2);
 /// ```
 // TODO: Consider using atomics. See
@@ -57,7 +57,12 @@ pub(crate) struct Inner {
 
 impl Histogram {
     /// Create a new [`Histogram`].
-    pub fn new(buckets: impl Iterator<Item = f64>) -> Self {
+    ///
+    /// ```rust
+    /// # use prometheus_client::metrics::histogram::Histogram;
+    /// let histogram = Histogram::new([10.0, 100.0, 1_000.0]);
+    /// ```
+    pub fn new(buckets: impl IntoIterator<Item = f64>) -> Self {
         Self {
             inner: Arc::new(RwLock::new(Inner {
                 sum: Default::default(),


### PR DESCRIPTION
this is a very small, **non-breaking**, alteration to the signature of `Histogram`'s constructor.

rather than accepting an `impl Iterator`, this commit changes the parameter of `Histogram::new()` to be an `impl IntoIterator` instead. this does not affect the existing contract because of the blanket `impl<I: Iterator> IntoIterator for I` implementation provided by the standard library.

by accepting `IntoIterator` however, callers providing a collection such as a `[f64; 5]` array or a `Vec<f64>` vector do not need to invoke `into_iter()` themselves at the call-site.

```rust
// now, constructing a histogram needn't involve `into_iter()`...
use prometheus_client::metrics::histogram::Histogram;
let histogram = Histogram::new([10.0, 100.0, 1_000.0]);
```

this leans on the same sugar used by `for {}` loops, see the relevant section of the `std::iter` documentation here:
<https://doc.rust-lang.org/stable/std/iter/index.html#for-loops-and-intoiterator>

no changes are needed within `Histogram::new()` because we already call `into_iter()` on the provider iterator when appending `f64::MAX` and collecting the buckets into a `Vec<_>`.