### PR TITLE
feat(metrics/family): `len()` returns the number of metrics

### DIFF
--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -288,6 +288,28 @@ impl<S: Clone + std::hash::Hash + Eq, M, C: MetricConstructor<M>> Family<S, M, C
         self.metrics.write().clear()
     }
 
+    /// Returns the number of metrics in this family.
+    ///
+    /// ```
+    /// # use prometheus_client::metrics::counter::{Atomic, Counter};
+    /// # use prometheus_client::metrics::family::Family;
+    /// #
+    /// let family = Family::<Vec<(String, String)>, Counter>::default();
+    /// assert_eq!(family.len(), 0);
+    ///
+    /// // Will create the metric with label `method="GET"` on first call and
+    /// // return a reference.
+    /// family.get_or_create(&vec![("method".to_owned(), "GET".to_owned())]).inc();
+    /// assert_eq!(family.len(), 1);
+    ///
+    /// // Clear the family of all label sets.
+    /// family.clear();
+    /// assert_eq!(family.len(), 0);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.metrics.read().len()
+    }
+
     pub(crate) fn read(&self) -> RwLockReadGuard<HashMap<S, M>> {
         self.metrics.read()
     }


### PR DESCRIPTION
this commit introduces a `len()` method to `Family<S, M, C>`, which returns the number of series within a metric family.

see also #245, which allows callers to check if a family `contains()` a given label set.