### PR TITLE
chore: 💜 add `CONTRIBUTING.md` instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Protocol Buffers
+
+The `build.rs` script in this library depends upon the
+[Protocol Buffers compiler][protoc]. Be sure that `protoc` is installed and
+available within your `PATH`.
+
+[protoc]: https://docs.rs/prost-build/latest/prost_build/#sourcing-protoc
+
+## Python Dependencies
+
+This repository uses the [`prometheus-client`][client-python] Python client
+library in its test suite.
+
+You may create and activate a virtual environment with this dependency
+installed by running the following shell commands from the root of this
+repository:
+
+```shell
+python -m venv ./venv
+source venv/bin/activate
+pip install prometheus-client
+```
+
+[client-python]: https://github.com/prometheus/client_python


### PR DESCRIPTION
the test suite in this repository has some implicit dependencies upon `protoc` and the Python client library.

in order to help newcomers get situated and effectively contributing to this project, a `CONTRIBUTING.md` file is added to help provide some guidance on how to install the protocol buffer compiler, and how to create and activate a virtual environment with the Python library installed.