### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/src/encoding/protobuf.rs
+++ b/src/encoding/protobuf.rs
@@ -14,7 +14,7 @@
 //! #   counter.clone(),
 //! # );
 //! # counter.inc();
-//! // Returns `MetricSet`, the top-level container type. Please refer to [openmetrics_data_model.proto](https://github.com/OpenObservability/OpenMetrics/blob/main/proto/openmetrics_data_model.proto) for details.
+//! // Returns `MetricSet`, the top-level container type. Please refer to [openmetrics_data_model.proto](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/proto/openmetrics_data_model.proto) for details.
 //! let metric_set = encode(&registry).unwrap();
 //!
 //! let family = metric_set.metric_families.first().unwrap();

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -53,7 +53,7 @@ use std::fmt::Write;
 ///
 /// Use [`encode_registry`] or [`encode_eof`] if partial encoding is needed.
 ///
-/// See [OpenMetrics exposition format](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#text-format)
+/// See [OpenMetrics exposition format](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#text-format)
 /// for additional details.
 ///
 /// # Examples


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.