### PR TITLE
feat: Add Summary metric type 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/prometheus-client"
 [features]
 default = []
 protobuf = ["dep:prost", "dep:prost-types", "dep:prost-build"]
+summary = ["dep:fastant", "dep:quantiles"]
 
 [workspace]
 members = ["derive-encode"]
@@ -22,8 +23,12 @@ dtoa = "1.0"
 itoa = "1.0"
 parking_lot = "0.12"
 prometheus-client-derive-encode = { version = "0.4.1", path = "derive-encode" }
-prost = { version = "0.12.0", optional = true }
-prost-types = { version = "0.12.0", optional = true }
+
+# Optional dependencies
+fastant = { version = "0.1", optional = true }
+prost = { version = "0.12", optional = true }
+prost-types = { version = "0.12", optional = true }
+quantiles = { version = "0.7", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -186,6 +186,22 @@ impl MetricEncoder<'_> {
         )
     }
 
+    /// Encode a summary.
+    #[cfg(feature = "summary")]
+    pub fn encode_summary<S: EncodeLabelSet>(
+        &mut self,
+        sum: f64,
+        count: u64,
+        quantiles: &[(f64, f64)],
+    ) -> Result<(), std::fmt::Error> {
+        for_both_mut!(
+            self,
+            MetricEncoderInner,
+            e,
+            e.encode_summary::<S>(sum, count, quantiles)
+        )
+    }
+
     /// Encode a metric family.
     pub fn encode_family<'s, S: EncodeLabelSet>(
         &'s mut self,

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -395,6 +395,40 @@ impl MetricEncoder<'_> {
         })
     }
 
+    #[cfg(feature = "summary")]
+    pub fn encode_summary<S: EncodeLabelSet>(
+        &mut self,
+        sum: f64,
+        count: u64,
+        quantiles: &[(f64, f64)],
+    ) -> Result<(), std::fmt::Error> {
+        self.write_prefix_name_unit()?;
+        self.write_suffix("sum")?;
+        self.encode_labels::<NoLabelSet>(None)?;
+        self.writer.write_str(" ")?;
+        self.writer.write_str(dtoa::Buffer::new().format(sum))?;
+        self.newline()?;
+
+        self.write_prefix_name_unit()?;
+        self.write_suffix("count")?;
+        self.encode_labels::<NoLabelSet>(None)?;
+        self.writer.write_str(" ")?;
+        self.writer.write_str(itoa::Buffer::new().format(count))?;
+        self.newline()?;
+
+        for (_, (quantile, result)) in quantiles.iter().enumerate() {
+            self.write_prefix_name_unit()?;
+            self.encode_labels(Some(&[("quantile", *quantile)]))?;
+
+            self.writer.write_str(" ")?;
+            self.writer.write_str(result.to_string().as_str())?;
+
+            self.newline()?;
+        }
+
+        Ok(())
+    }
+
     pub fn encode_histogram<S: EncodeLabelSet>(
         &mut self,
         sum: f64,
@@ -1158,6 +1192,34 @@ mod tests {
 
         encode_eof(&mut response).unwrap();
         assert_eq!(&response[response.len() - 20..], "ogins_total 0\n# EOF\n");
+    }
+
+    #[cfg(feature = "summary")]
+    #[test]
+    fn encode_summary() {
+        use crate::metrics::summary::Summary;
+
+        let mut registry = Registry::default();
+        let summary = Summary::new(3, 10, vec![0.5, 0.9, 0.99], 0.0);
+        registry.register("my_summary", "My summary", summary.clone());
+        summary.observe(0.10);
+        summary.observe(0.20);
+        summary.observe(0.30);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        let expected = "# HELP my_summary My summary.\n".to_owned()
+            + "# TYPE my_summary summary\n"
+            + "my_summary_sum 0.6000000000000001\n"
+            + "my_summary_count 3\n"
+            + "my_summary{quantile=\"0.5\"} 0.2\n"
+            + "my_summary{quantile=\"0.9\"} 0.3\n"
+            + "my_summary{quantile=\"0.99\"} 0.3\n"
+            + "# EOF\n";
+        assert_eq!(expected, encoded);
+
+        parse_with_python_client(encoded);
     }
 
     fn parse_with_python_client(input: String) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,6 +6,8 @@ pub mod family;
 pub mod gauge;
 pub mod histogram;
 pub mod info;
+#[cfg(feature = "summary")]
+pub mod summary;
 
 /// A metric that is aware of its Open Metrics metric type.
 pub trait TypedMetric {
@@ -21,12 +23,13 @@ pub enum MetricType {
     Gauge,
     Histogram,
     Info,
+    #[cfg(feature = "summary")]
+    Summary,
     Unknown,
     // Not (yet) supported metric types.
     //
     // GaugeHistogram,
     // StateSet,
-    // Summary
 }
 
 impl MetricType {
@@ -37,6 +40,8 @@ impl MetricType {
             MetricType::Gauge => "gauge",
             MetricType::Histogram => "histogram",
             MetricType::Info => "info",
+            #[cfg(feature = "summary")]
+            MetricType::Summary => "summary",
             MetricType::Unknown => "unknown",
         }
     }

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -265,7 +265,7 @@ mod tests {
                 // Map infinite, subnormal and NaN to 0.0.
                 .map(|f| if f.is_normal() { f } else { 0.0 })
                 .collect();
-            let sum = fs.iter().sum();
+            let sum: f64 = fs.iter().sum();
             let counter = Counter::<f64, AtomicU64>::default();
             for f in fs {
                 counter.inc_by(f);

--- a/src/metrics/summary.rs
+++ b/src/metrics/summary.rs
@@ -1,0 +1,167 @@
+//! Module implementing an Open Metrics summary.
+//!
+//! See [`Summary`] for details.
+
+use crate::encoding::{EncodeMetric, MetricEncoder, NoLabelSet};
+use crate::metrics::{MetricType, TypedMetric};
+use fastant::Instant;
+use parking_lot::RwLock;
+use quantiles::ckms::CKMS;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Open Metrics [`Summary`] to measure distributions of discrete events.
+#[derive(Debug)]
+pub struct Summary {
+    target_quantile: Vec<f64>,
+    target_error: f64,
+    max_age_buckets: usize,
+    max_age_seconds: u64,
+    stream_duration: Duration,
+    inner: Arc<RwLock<InnerSummary>>,
+}
+
+impl Clone for Summary {
+    fn clone(&self) -> Self {
+        Summary {
+            target_quantile: self.target_quantile.clone(),
+            target_error: self.target_error,
+            max_age_buckets: self.max_age_buckets,
+            max_age_seconds: self.max_age_seconds,
+            stream_duration: self.stream_duration,
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct InnerSummary {
+    sum: f64,
+    count: u64,
+    quantile_streams: Vec<CKMS<f64>>,
+    // head_stream is like a cursor which carries the index
+    // of the stream in the quantile_streams that we want to query.
+    head_stream_idx: usize,
+    // timestamp at which the head_stream_idx was last rotated.
+    last_rotated_timestamp: Instant,
+}
+
+impl Summary {
+    /// Create a new [`Summary`].
+    pub fn new(
+        max_age_buckets: usize,
+        max_age_seconds: u64,
+        target_quantile: Vec<f64>,
+        target_error: f64,
+    ) -> Self {
+        let mut streams: Vec<CKMS<f64>> = Vec::new();
+        for _ in 0..max_age_buckets {
+            streams.push(CKMS::new(target_error));
+        }
+
+        let stream_duration = Duration::from_secs(max_age_seconds / (max_age_buckets as u64));
+        let last_rotated_timestamp = Instant::now();
+
+        if target_quantile.iter().any(|&x| x > 1.0 || x < 0.0) {
+            panic!("Quantile value out of range");
+        }
+
+        Summary {
+            max_age_buckets,
+            max_age_seconds,
+            stream_duration,
+            target_quantile,
+            target_error,
+            inner: Arc::new(RwLock::new(InnerSummary {
+                sum: Default::default(),
+                count: Default::default(),
+                quantile_streams: streams,
+                head_stream_idx: 0,
+                last_rotated_timestamp,
+            })),
+        }
+    }
+
+    /// Observe the given value.
+    pub fn observe(&self, v: f64) {
+        self.rotate_buckets();
+
+        let mut inner = self.inner.write();
+        inner.sum += v;
+        inner.count += 1;
+
+        // insert quantiles into all streams/buckets.
+        for stream in inner.quantile_streams.iter_mut() {
+            stream.insert(v);
+        }
+    }
+
+    /// Retrieve the values of the summary metric.
+    pub(crate) fn get(&self) -> (f64, u64, Vec<(f64, f64)>) {
+        self.rotate_buckets();
+
+        let inner = self.inner.read();
+        let sum = inner.sum;
+        let count = inner.count;
+        let mut quantile_values: Vec<(f64, f64)> = Vec::new();
+
+        for q in self.target_quantile.iter() {
+            match inner.quantile_streams[inner.head_stream_idx].query(*q) {
+                Some((_, v)) => quantile_values.push((*q, v)),
+                None => continue,
+            };
+        }
+        (sum, count, quantile_values)
+    }
+
+    fn rotate_buckets(&self) {
+        let mut inner = self.inner.write();
+        if inner.last_rotated_timestamp.elapsed() >= self.stream_duration {
+            inner.last_rotated_timestamp = Instant::now();
+            if inner.head_stream_idx == self.max_age_buckets {
+                inner.head_stream_idx = 0;
+            } else {
+                inner.head_stream_idx += 1;
+            }
+        };
+    }
+}
+
+impl TypedMetric for Summary {
+    const TYPE: MetricType = MetricType::Summary;
+}
+
+impl EncodeMetric for Summary {
+    fn encode(&self, mut encoder: MetricEncoder) -> Result<(), std::fmt::Error> {
+        let (sum, count, quantiles) = self.get();
+        encoder.encode_summary::<NoLabelSet>(sum, count, &quantiles)
+    }
+
+    fn metric_type(&self) -> MetricType {
+        Self::TYPE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary() {
+        let summary = Summary::new(5, 10, vec![0.5, 0.9, 0.99], 0.01);
+        summary.observe(1.0);
+        summary.observe(5.0);
+        summary.observe(10.0);
+
+        let (s, c, q) = summary.get();
+        assert_eq!(16.0, s);
+        assert_eq!(3, c);
+        assert_eq!(vec![(0.5, 5.0), (0.9, 10.0), (0.99, 10.0)], q);
+    }
+
+    #[test]
+    #[should_panic(expected = "Quantile value out of range")]
+    fn summary_panic() {
+        Summary::new(5, 10, vec![1.0, 5.0, 9.0], 0.01);
+    }
+}


### PR DESCRIPTION
This closes #40.

This follows up https://github.com/prometheus/client_rust/pull/67.

With ...

* https://github.com/prometheus/client_rust/pull/67/files#r1145927745 Resolved. All related code is behind "summary" feature now.
* https://github.com/prometheus/client_rust/pull/67/files#r1145930654 Resolved. crate `instant` is not maintained any more, using `fastant` which works on wasm also.
* https://github.com/prometheus/client_rust/pull/67/files#r1145938371 Resolved. TRIVIAL AS IS.
* https://github.com/prometheus/client_rust/pull/67/files#r1145924555 Resolved. Use the same write lock when needed. See 22865b4d3d01d6870360c3ffe3ce4d100ccc36d5.
* https://github.com/prometheus/client_rust/pull/67/files#r1145932768 Resolved. TRIVIAL AS IS.
* https://github.com/prometheus/client_rust/pull/67/files#r1145935223 Not accepted. We may improve this point later. Currently it brings extra burden without clearly benefit.