### PR TITLE
fix(derive-encode): expand prelude symbols to absolute paths

### DIFF
--- a/derive-encode/Cargo.toml
+++ b/derive-encode/Cargo.toml
@@ -18,6 +18,7 @@ syn = "2"
 
 [dev-dependencies]
 prometheus-client = { path = "../", features = ["protobuf"] }
+trybuild = "1"
 
 [lib]
 proc-macro = true

--- a/derive-encode/src/lib.rs
+++ b/derive-encode/src/lib.rs
@@ -71,15 +71,15 @@ pub fn derive_encode_label_set(input: TokenStream) -> TokenStream {
     };
 
     let gen = quote! {
-        impl prometheus_client::encoding::EncodeLabelSet for #name {
-            fn encode(&self, encoder: &mut prometheus_client::encoding::LabelSetEncoder) -> std::result::Result<(), std::fmt::Error> {
-                use prometheus_client::encoding::EncodeLabel;
-                use prometheus_client::encoding::EncodeLabelKey;
-                use prometheus_client::encoding::EncodeLabelValue;
+        impl ::prometheus_client::encoding::EncodeLabelSet for #name {
+            fn encode(&self, encoder: &mut ::prometheus_client::encoding::LabelSetEncoder) -> ::core::result::Result<(), ::core::fmt::Error> {
+                use ::prometheus_client::encoding::EncodeLabel;
+                use ::prometheus_client::encoding::EncodeLabelKey;
+                use ::prometheus_client::encoding::EncodeLabelValue;
 
                 #body
 
-                Ok(())
+                ::core::result::Result::Ok(())
             }
         }
     };
@@ -118,13 +118,13 @@ pub fn derive_encode_label_value(input: TokenStream) -> TokenStream {
     };
 
     let gen = quote! {
-        impl prometheus_client::encoding::EncodeLabelValue for #name {
-            fn encode(&self, encoder: &mut prometheus_client::encoding::LabelValueEncoder) -> std::result::Result<(), std::fmt::Error> {
-                use std::fmt::Write;
+        impl ::prometheus_client::encoding::EncodeLabelValue for #name {
+            fn encode(&self, encoder: &mut ::prometheus_client::encoding::LabelValueEncoder) -> ::core::result::Result<(), ::core::fmt::Error> {
+                use ::core::fmt::Write;
 
                 #body
 
-                Ok(())
+                ::core::result::Result::Ok(())
             }
         }
     };

--- a/derive-encode/tests/build/redefine-prelude-symbols.rs
+++ b/derive-encode/tests/build/redefine-prelude-symbols.rs
@@ -1,0 +1,36 @@
+#![allow(unused_imports)]
+
+// empty module has nothing and be used to redefine symbols
+mod empty {}
+
+// redefine the prelude `::std`
+use empty as std;
+
+// redefine the dependency `::prometheus_client`
+use empty as prometheus_client;
+
+// redefine the prelude `::core::result::Result`.
+type Result = ();
+
+enum TResult {
+    Ok,
+    Err,
+}
+
+// redefine the prelude `::core::result::Result::Ok/Err`.
+use TResult::Ok;
+use TResult::Err;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ::prometheus_client::encoding::EncodeLabelSet)]
+struct LableSet {
+    a: String,
+    b: LabelEnum,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ::prometheus_client::encoding::EncodeLabelValue)]
+enum LabelEnum {
+    A,
+    B,
+}
+
+fn main() {}

--- a/derive-encode/tests/build/redefine-prelude-symbols.rs
+++ b/derive-encode/tests/build/redefine-prelude-symbols.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-// empty module has nothing and be used to redefine symbols
+// Empty module has nothing and can be used to redefine symbols.
 mod empty {}
 
 // redefine the prelude `::std`

--- a/derive-encode/tests/lib.rs
+++ b/derive-encode/tests/lib.rs
@@ -205,3 +205,9 @@ fn flatten() {
         + "# EOF\n";
     assert_eq!(expected, buffer);
 }
+
+#[test]
+fn build() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/build/redefine-prelude-symbols.rs")
+}


### PR DESCRIPTION
## Summary

This PR expands prelude symbols like `Ok()` and `prometheus_client` to absolute paths to make it more hygienic.

## Full changes

1. Add new dev-dependency [`trybuild`](https://docs.rs/trybuild/latest/trybuild/) to test procedure macro.
2. Expand the following symbols to absolute paths
    1. `prometheus_client::encoding::*` -> `::prometheus_client::encoding::*`
    2. `std::result::Result` -> `::core::result::Result`
    3. `std::fmt::Error` -> `::core::fmt::Error`
    4. `Ok(())` -> `::core::result::Result::Ok(())`
    5. `std::fmt::Write` -> `::core::fmt::Write`

## References

According to [proc-macro-workshop]:
> Generally all macros (procedural as well as macro_rules) designed to be used
> by other people should refer to every single thing in their expanded code
> through an absolute path, such as std::result::Result.

[proc-macro-workshop]: https://github.com/dtolnay/proc-macro-workshop/blob/3b6bcd2c3ad1c1946e6fbcc9be25d3890876087d/builder/tests/09-redefined-prelude-types.rs#L13C1-L15C58

## Issues

Closes #266