### PR TITLE
feat: impl<T: Collector> Collector for std::sync::Arc<T>

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -39,3 +39,9 @@ pub trait Collector: std::fmt::Debug + Send + Sync + 'static {
     /// Once the [`Collector`] is registered, this method is called on each scrape.
     fn encode(&self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error>;
 }
+
+impl<T: Collector> Collector for std::sync::Arc<T> {
+    fn encode(&self, encoder: DescriptorEncoder) -> Result<(), std::fmt::Error> {
+        self.as_ref().encode(encoder)
+    }
+}


### PR DESCRIPTION
This PR implements `Collector` for `std::sync::Arc<T>` where `T: Collector`. This is useful for registering an `Arc` pointer of the metrics tracker instead of wrapping tracker fields with `Arc`