### PR TITLE
Substitute `HashMap` for `BtreeMap` in family

### DIFF
--- a/benches/encoding/proto.rs
+++ b/benches/encoding/proto.rs
@@ -1,36 +1,40 @@
 // Benchmark inspired by
 // https://github.com/tikv/rust-prometheus/blob/ab1ca7285d3463504381a5025ae1951e020d6796/benches/text_encoder.rs:write
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use prometheus_client::encoding::prometheus_protobuf;
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
-use prometheus_client::registry::Registry;
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use prometheus_client::{
+    encoding::prometheus_protobuf,
+    metrics::{
+        counter::Counter,
+        family::Family,
+        histogram::{Histogram, exponential_buckets},
+    },
+    registry::Registry,
+};
 use prometheus_client_derive_encode::{EncodeLabelSet, EncodeLabelValue};
 
 pub fn proto(c: &mut Criterion) {
     c.bench_function("encode", |b| {
-        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug)]
+        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug, PartialOrd, Ord)]
         struct CounterLabels {
             path: String,
             method: Method,
             some_number: u64,
         }
 
-        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelValue, Debug)]
+        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelValue, Debug, PartialOrd, Ord)]
         enum Method {
             Get,
             #[allow(dead_code)]
             Put,
         }
 
-        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug)]
+        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug, PartialOrd, Ord)]
         struct HistogramLabels {
             region: Region,
         }
 
-        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelValue, Debug)]
+        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelValue, Debug, PartialOrd, Ord)]
         enum Region {
             Africa,
             #[allow(dead_code)]

--- a/benches/encoding/text.rs
+++ b/benches/encoding/text.rs
@@ -10,21 +10,21 @@ use std::fmt::Write;
 
 pub fn text(c: &mut Criterion) {
     c.bench_function("encode", |b| {
-        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug)]
+        #[derive(Clone, Ord, PartialOrd, PartialEq, Eq, EncodeLabelSet, Debug)]
         struct Labels {
             method: Method,
             status: Status,
             some_number: u64,
         }
 
-        #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelValue, Debug)]
+        #[derive(Clone, Ord, PartialOrd, PartialEq, Eq, EncodeLabelValue, Debug)]
         enum Method {
             Get,
             #[allow(dead_code)]
             Put,
         }
 
-        #[derive(Clone, Hash, PartialEq, Eq, Debug)]
+        #[derive(Clone, Ord, PartialOrd, PartialEq, Eq, Debug)]
         enum Status {
             Two,
             #[allow(dead_code)]

--- a/benches/family.rs
+++ b/benches/family.rs
@@ -43,20 +43,20 @@ pub fn family(c: &mut Criterion) {
     });
 
     c.bench_function("counter family with custom type label set", |b| {
-        #[derive(Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Ord, PartialOrd, PartialEq, Eq)]
         struct Labels {
             method: Method,
             status: Status,
         }
 
-        #[derive(Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Ord, PartialOrd, PartialEq, Eq)]
         enum Method {
             Get,
             #[allow(dead_code)]
             Put,
         }
 
-        #[derive(Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Ord, PartialOrd, PartialEq, Eq)]
         enum Status {
             Two,
             #[allow(dead_code)]

--- a/derive-encode/tests/lib.rs
+++ b/derive-encode/tests/lib.rs
@@ -1,18 +1,18 @@
 use std::sync::Arc;
 
-use prometheus_client::encoding::text::encode;
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::registry::Registry;
+use prometheus_client::{
+    encoding::{EncodeLabelSet, EncodeLabelValue, text::encode},
+    metrics::{counter::Counter, family::Family},
+    registry::Registry,
+};
 
-#[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug, PartialOrd, Ord)]
 struct Labels {
     method: Method,
     path: String,
 }
 
-#[derive(Clone, Hash, PartialEq, Eq, EncodeLabelValue, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, EncodeLabelValue, Debug, PartialOrd, Ord)]
 enum Method {
     Get,
     #[allow(dead_code)]
@@ -47,11 +47,11 @@ fn basic_flow() {
 
 mod protobuf {
     use crate::{Labels, Method};
-    use prometheus_client::encoding::prometheus_protobuf::encode;
-    use prometheus_client::encoding::prometheus_protobuf::prometheus_data_model;
-    use prometheus_client::metrics::counter::Counter;
-    use prometheus_client::metrics::family::Family;
-    use prometheus_client::registry::Registry;
+    use prometheus_client::{
+        encoding::prometheus_protobuf::{encode, prometheus_data_model},
+        metrics::{counter::Counter, family::Family},
+        registry::Registry,
+    };
 
     #[test]
     fn structs() {
@@ -106,7 +106,7 @@ mod protobuf {
 
 #[test]
 fn remap_keyword_identifiers() {
-    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug, PartialOrd, Ord)]
     struct Labels {
         // `r#type` is problematic as `r#` is not a valid OpenMetrics label name
         // but one needs to use keyword identifier syntax (aka. raw identifiers)
@@ -137,7 +137,7 @@ fn remap_keyword_identifiers() {
 
 #[test]
 fn arc_string() {
-    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug, PartialOrd, Ord)]
     struct Labels {
         client_id: Arc<String>,
     }
@@ -167,12 +167,12 @@ fn arc_string() {
 
 #[test]
 fn flatten() {
-    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug, PartialOrd, Ord)]
     struct CommonLabels {
         a: u64,
         b: u64,
     }
-    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug)]
+    #[derive(EncodeLabelSet, Hash, Clone, Eq, PartialEq, Debug, PartialOrd, Ord)]
     struct Labels {
         unique: u64,
         #[prometheus(flatten)]

--- a/examples/actix-web.rs
+++ b/examples/actix-web.rs
@@ -8,13 +8,13 @@ use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::registry::Registry;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelValue)]
 pub enum Method {
     Get,
     Post,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
 pub struct MethodLabels {
     pub method: Method,
 }

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -13,13 +13,13 @@ use prometheus_client_derive_encode::{EncodeLabelSet, EncodeLabelValue};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+#[derive(Clone, Debug, Ord, PartialOrd, PartialEq, Eq, EncodeLabelValue)]
 pub enum Method {
     Get,
     Post,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Debug, Ord, PartialOrd, PartialEq, Eq, EncodeLabelSet)]
 pub struct MethodLabels {
     pub method: Method,
 }

--- a/examples/tide.rs
+++ b/examples/tide.rs
@@ -44,13 +44,13 @@ async fn main() -> std::result::Result<(), std::io::Error> {
     Ok(())
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
 struct Labels {
     method: Method,
     path: String,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelValue)]
 enum Method {
     Get,
     Put,

--- a/examples/tide.rs
+++ b/examples/tide.rs
@@ -44,13 +44,13 @@ async fn main() -> std::result::Result<(), std::io::Error> {
     Ok(())
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
 struct Labels {
     method: Method,
     path: String,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, EncodeLabelValue)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelValue)]
 enum Method {
     Get,
     Put,

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -1398,20 +1398,20 @@ def parse(input):
     }
 
     #[test]
-    fn metric_family_is_sorted_by_registration_order() {
+    fn metric_family_is_sorted_lexicographically() {
         let mut registry = Registry::default();
         let gauge = Family::<Vec<(String, String)>, Gauge>::default();
         registry.register("my_gauge", "My gauge", gauge.clone());
 
-        {
-            let gauge0 = gauge.get_or_create(&vec![("label".to_string(), "0".to_string())]);
-            gauge0.set(0);
-        }
-
-        {
-            let gauge1 = gauge.get_or_create(&vec![("label".to_string(), "1".to_string())]);
-            gauge1.set(1);
-        }
+        gauge
+            .get_or_create(&vec![("label".to_string(), "0".to_string())])
+            .set(0);
+        gauge
+            .get_or_create(&vec![("label".to_string(), "2".to_string())])
+            .set(2);
+        gauge
+            .get_or_create(&vec![("label".to_string(), "1".to_string())])
+            .set(1);
 
         let mut encoded = String::new();
         encode(&mut encoded, &registry).unwrap();
@@ -1420,6 +1420,7 @@ def parse(input):
             + "# TYPE my_gauge gauge\n"
             + "my_gauge{label=\"0\"} 0\n"
             + "my_gauge{label=\"1\"} 1\n"
+            + "my_gauge{label=\"2\"} 2\n"
             + "# EOF\n";
         assert_eq!(expected, encoded);
     }

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -37,16 +37,15 @@
 //! assert_eq!(expected_msg, buffer);
 //! ```
 
-use crate::encoding::{
-    EncodeExemplarTime, EncodeExemplarValue, EncodeLabelSet, NativeHistogram, NoLabelSet,
+use crate::{
+    encoding::{
+        EncodeExemplarTime, EncodeExemplarValue, EncodeLabelSet, NativeHistogram, NoLabelSet,
+    },
+    metrics::{MetricType, exemplar::Exemplar},
+    registry::{Prefix, Registry, Unit},
 };
-use crate::metrics::exemplar::Exemplar;
-use crate::metrics::MetricType;
-use crate::registry::{Prefix, Registry, Unit};
 
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::fmt::Write;
+use std::{borrow::Cow, collections::HashMap, fmt::Write};
 
 /// Encode both the metrics registered with the provided [`Registry`] and the
 /// EOF marker into the provided [`Write`]r using the OpenMetrics text format.
@@ -759,17 +758,21 @@ impl std::fmt::Write for LabelValueEncoder<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metrics::exemplar::HistogramWithExemplars;
-    use crate::metrics::family::Family;
-    use crate::metrics::gauge::Gauge;
-    use crate::metrics::histogram::{exponential_buckets, Histogram, NativeHistogramConfig};
-    use crate::metrics::info::Info;
-    use crate::metrics::{counter::Counter, exemplar::CounterWithExemplar};
+    use crate::metrics::{
+        counter::Counter,
+        exemplar::{CounterWithExemplar, HistogramWithExemplars},
+        family::Family,
+        gauge::Gauge,
+        histogram::{Histogram, NativeHistogramConfig, exponential_buckets},
+        info::Info,
+    };
     use pyo3::{prelude::*, types::PyModule};
-    use std::borrow::Cow;
-    use std::fmt::Error;
-    use std::sync::atomic::{AtomicI32, AtomicU32};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        borrow::Cow,
+        fmt::Error,
+        sync::atomic::{AtomicI32, AtomicU32},
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn encode_counter() {
@@ -916,8 +919,7 @@ mod tests {
 
         encode(&mut encoded, &registry).unwrap();
 
-        let expected = "# HELP my_prefix_my_counter_family My counter family.\n"
-            .to_owned()
+        let expected = "# HELP my_prefix_my_counter_family My counter family.\n".to_owned()
             + "# TYPE my_prefix_my_counter_family counter\n"
             + "my_prefix_my_counter_family_total{my_key=\"my_value\",method=\"GET\",status=\"200\"} 1\n"
             + "# EOF\n";
@@ -1020,7 +1022,7 @@ mod tests {
             Family::new_with_constructor(|| Histogram::new(exponential_buckets(1.0, 2.0, 10)));
         registry.register("my_histogram", "My histogram", family.clone());
 
-        #[derive(Eq, PartialEq, Hash, Debug, Clone)]
+        #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone)]
         struct EmptyLabels {}
 
         impl EncodeLabelSet for EmptyLabels {
@@ -1210,7 +1212,7 @@ mod tests {
 
     #[test]
     fn label_sets_can_be_composed() {
-        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+        #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
         struct Color(&'static str);
         impl EncodeLabelSet for Color {
             fn encode(
@@ -1225,7 +1227,7 @@ mod tests {
             }
         }
 
-        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+        #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
         struct Size(&'static str);
         impl EncodeLabelSet for Size {
             fn encode(
@@ -1370,6 +1372,54 @@ def parse(input):
             + "# HELP counter2 Second counter.\n"
             + "# TYPE counter2 counter\n"
             + "counter2_total{label=\"value\"} 1\n"
+            + "# EOF\n";
+        assert_eq!(expected, encoded);
+    }
+
+    #[test]
+    fn metrics_are_sorted_by_registration_order() {
+        let mut registry = Registry::default();
+        let counter: Counter = Counter::default();
+        let another_counter: Counter = Counter::default();
+        registry.register("my_counter", "My counter", counter);
+        registry.register("another_counter", "Another counter", another_counter);
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        let expected = "# HELP my_counter My counter.\n".to_owned()
+            + "# TYPE my_counter counter\n"
+            + "my_counter_total 0\n"
+            + "# HELP another_counter Another counter.\n"
+            + "# TYPE another_counter counter\n"
+            + "another_counter_total 0\n"
+            + "# EOF\n";
+        assert_eq!(expected, encoded);
+    }
+
+    #[test]
+    fn metric_family_is_sorted_by_registration_order() {
+        let mut registry = Registry::default();
+        let gauge = Family::<Vec<(String, String)>, Gauge>::default();
+        registry.register("my_gauge", "My gauge", gauge.clone());
+
+        {
+            let gauge0 = gauge.get_or_create(&vec![("label".to_string(), "0".to_string())]);
+            gauge0.set(0);
+        }
+
+        {
+            let gauge1 = gauge.get_or_create(&vec![("label".to_string(), "1".to_string())]);
+            gauge1.set(1);
+        }
+
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).unwrap();
+
+        let expected = "# HELP my_gauge My gauge.\n".to_owned()
+            + "# TYPE my_gauge gauge\n"
+            + "my_gauge{label=\"0\"} 0\n"
+            + "my_gauge{label=\"1\"} 1\n"
             + "# EOF\n";
         assert_eq!(expected, encoded);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! //
 //! // You could as well use `(String, String)` to represent a label set,
 //! // instead of the custom type below.
-//! #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+//! #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
 //! struct Labels {
 //!   // Use your own enum types to represent label values.
 //!   method: Method,
@@ -39,7 +39,7 @@
 //!   path: String,
 //! };
 //!
-//! #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+//! #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelValue)]
 //! enum Method {
 //!   GET,
 //!   PUT,

--- a/src/metrics/exemplar.rs
+++ b/src/metrics/exemplar.rs
@@ -44,12 +44,12 @@ pub struct Exemplar<S, V> {
 /// # use prometheus_client::metrics::histogram::exponential_buckets;
 /// # use prometheus_client::metrics::family::Family;
 /// # use prometheus_client_derive_encode::EncodeLabelSet;
-/// #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug, Default)]
+/// #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet, Debug, Default)]
 /// pub struct ResultLabel {
 ///     pub result: String,
 /// }
 ///
-/// #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug, Default)]
+/// #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet, Debug, Default)]
 /// pub struct TraceLabel {
 ///     pub trace_id: String,
 /// }
@@ -187,12 +187,12 @@ where
 /// # use prometheus_client::metrics::histogram::exponential_buckets;
 /// # use prometheus_client::metrics::family::Family;
 /// # use prometheus_client::encoding::EncodeLabelSet;
-/// #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug, Default)]
+/// #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet, Debug, Default)]
 /// pub struct ResultLabel {
 ///     pub result: String,
 /// }
 ///
-/// #[derive(Clone, Hash, PartialEq, Eq, EncodeLabelSet, Debug, Default)]
+/// #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet, Debug, Default)]
 /// pub struct TraceLabel {
 ///     pub trace_id: String,
 /// }

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -166,7 +166,7 @@ impl<M, F: Fn() -> M> MetricConstructor<M> for F {
     }
 }
 
-impl<S: Clone + Eq, M: Default> Default for Family<S, M> {
+impl<S: Clone + Eq + Ord, M: Default> Default for Family<S, M> {
     fn default() -> Self {
         Self {
             metrics: Arc::new(RwLock::new(Default::default())),
@@ -175,7 +175,7 @@ impl<S: Clone + Eq, M: Default> Default for Family<S, M> {
     }
 }
 
-impl<S: Clone + Eq, M, C> Family<S, M, C> {
+impl<S: Clone + Eq + Ord, M, C> Family<S, M, C> {
     /// Create a metric family using a custom constructor to construct new
     /// metrics.
     ///

--- a/src/metrics/family.rs
+++ b/src/metrics/family.rs
@@ -6,8 +6,7 @@ use crate::encoding::{EncodeLabelSet, EncodeMetric, MetricEncoder};
 
 use super::{MetricType, TypedMetric};
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 /// Representation of the OpenMetrics *MetricFamily* data type.
 ///
@@ -68,12 +67,12 @@ use std::sync::Arc;
 /// # use std::io::Write;
 /// #
 /// # let mut registry = Registry::default();
-/// #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+/// #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelSet)]
 /// struct Labels {
 ///   method: Method,
 /// };
 ///
-/// #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+/// #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EncodeLabelValue)]
 /// enum Method {
 ///   GET,
 ///   PUT,
@@ -99,9 +98,8 @@ use std::sync::Arc;
 /// #                "# EOF\n";
 /// # assert_eq!(expected, buffer);
 /// ```
-// TODO: Consider exposing hash algorithm.
 pub struct Family<S, M, C = fn() -> M> {
-    metrics: Arc<RwLock<HashMap<S, M>>>,
+    metrics: Arc<RwLock<BTreeMap<S, M>>>,
     /// Function that when called constructs a new metric.
     ///
     /// For most metric types this would simply be its [`Default`]
@@ -168,7 +166,7 @@ impl<M, F: Fn() -> M> MetricConstructor<M> for F {
     }
 }
 
-impl<S: Clone + std::hash::Hash + Eq, M: Default> Default for Family<S, M> {
+impl<S: Clone + Eq, M: Default> Default for Family<S, M> {
     fn default() -> Self {
         Self {
             metrics: Arc::new(RwLock::new(Default::default())),
@@ -177,7 +175,7 @@ impl<S: Clone + std::hash::Hash + Eq, M: Default> Default for Family<S, M> {
     }
 }
 
-impl<S: Clone + std::hash::Hash + Eq, M, C> Family<S, M, C> {
+impl<S: Clone + Eq, M, C> Family<S, M, C> {
     /// Create a metric family using a custom constructor to construct new
     /// metrics.
     ///
@@ -207,12 +205,7 @@ impl<S: Clone + std::hash::Hash + Eq, M, C> Family<S, M, C> {
     }
 }
 
-impl<S: Clone + std::hash::Hash + Eq, M: Clone, C: MetricConstructor<M>> Family<S, M, C>
-where
-    S: Clone + std::hash::Hash + Eq,
-    M: Clone,
-    C: MetricConstructor<M>,
-{
+impl<S: Clone + Eq + Ord, M: Clone, C: MetricConstructor<M>> Family<S, M, C> {
     /// Access a metric with the given label set, creating it if one does not yet exist.
     ///
     /// ```
@@ -241,7 +234,7 @@ where
     }
 }
 
-impl<S: Clone + std::hash::Hash + Eq, M, C: MetricConstructor<M>> Family<S, M, C> {
+impl<S: Clone + Eq + Ord, M, C: MetricConstructor<M>> Family<S, M, C> {
     /// Access a metric with the given label set, creating it if one does not
     /// yet exist.
     ///
@@ -391,7 +384,7 @@ impl<S: Clone + std::hash::Hash + Eq, M, C: MetricConstructor<M>> Family<S, M, C
         self.metrics.read().is_empty()
     }
 
-    pub(crate) fn read(&self) -> RwLockReadGuard<'_, HashMap<S, M>> {
+    pub(crate) fn read(&self) -> RwLockReadGuard<'_, BTreeMap<S, M>> {
         self.metrics.read()
     }
 }
@@ -411,7 +404,7 @@ impl<S, M: TypedMetric, C> TypedMetric for Family<S, M, C> {
 
 impl<S, M, C> EncodeMetric for Family<S, M, C>
 where
-    S: Clone + std::hash::Hash + Eq + EncodeLabelSet,
+    S: Clone + Eq + Ord + EncodeLabelSet,
     M: EncodeMetric + TypedMetric,
     C: MetricConstructor<M>,
 {
@@ -436,8 +429,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metrics::counter::Counter;
-    use crate::metrics::histogram::{exponential_buckets, Histogram};
+    use crate::metrics::{
+        counter::Counter,
+        histogram::{Histogram, exponential_buckets},
+    };
 
     #[test]
     fn counter_family() {


### PR DESCRIPTION
Updates #128, fixes #125.

Edit: updated numbers for 2026
```
     Running benches/baseline.rs (target/release/deps/baseline-afaf49df79a6aa37)
Gnuplot not found, using plotters backend
counter                 time:   [1.5237 ns 1.5238 ns 1.5240 ns]
                        change: [-0.1374% -0.0297% +0.0816%] (p = 0.61 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe

counter via family lookup
                        time:   [4.5786 ns 4.5919 ns 4.6077 ns]
                        change: [-1.3790% -1.0886% -0.7645%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

     Running benches/exemplars.rs (target/release/deps/exemplars-44e9e58bee91a180)
Gnuplot not found, using plotters backend
histogram without exemplars
                        time:   [5.2069 ns 5.2149 ns 5.2237 ns]
                        change: [-0.8447% -0.4973% -0.1840%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe

histogram with exemplars (no exemplar passed)
                        time:   [5.7712 ns 5.7765 ns 5.7835 ns]
                        change: [-2.3160% -2.0050% -1.6724%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  10 (10.00%) high mild
  2 (2.00%) high severe

histogram with exemplars (some exemplar passed)
                        time:   [46.992 ns 47.047 ns 47.105 ns]
                        change: [-6.1891% -5.2597% -4.3480%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

     Running benches/family.rs (target/release/deps/family-9fc0fb35439fee5b)
Gnuplot not found, using plotters backend
counter family with [(&'static str, &'static str)] label set
                        time:   [11.101 ns 11.173 ns 11.234 ns]
                        change: [-49.818% -49.403% -49.005%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild

counter family with Vec<(&'static str, &'static str)> label set
                        time:   [19.108 ns 19.205 ns 19.315 ns]
                        change: [-36.874% -36.427% -35.912%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

counter family with Vec<(String, String)> label set
                        time:   [53.065 ns 53.165 ns 53.279 ns]
                        change: [-16.658% -16.289% -15.940%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

counter family with custom type label set
                        time:   [5.1398 ns 5.1493 ns 5.1596 ns]
                        change: [-44.652% -44.504% -44.337%] (p = 0.00 < 0.05)
                        Performance has improved.

     Running benches/histogram.rs (target/release/deps/histogram-cbf0fe399db614ec)
Gnuplot not found, using plotters backend
observe/histogram       time:   [4.6503 ns 4.6601 ns 4.6698 ns]
                        change: [-1.4986% -0.9936% -0.4452%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low severe
  4 (4.00%) low mild
  1 (1.00%) high mild
observe/native histogram
                        time:   [5.3982 ns 5.3994 ns 5.4005 ns]
                        change: [-0.7902% -0.6653% -0.5421%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 18 outliers among 100 measurements (18.00%)
  2 (2.00%) low severe
  6 (6.00%) low mild
  3 (3.00%) high mild
  7 (7.00%) high severe
observe/classic and native histogram
                        time:   [5.6864 ns 5.6929 ns 5.7037 ns]
                        change: [-0.7474% -0.5332% -0.2340%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

     Running benches/encoding/text.rs (target/release/deps/text-742f9524329bef5c)
Gnuplot not found, using plotters backend
encode                  time:   [11.127 ms 11.169 ms 11.213 ms]
                        change: [+1.7567% +2.2668% +2.7645%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```