### PR TITLE
feat: introduce `test-util` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ documentation = "https://docs.rs/prometheus-client"
 default = []
 protobuf = ["dep:prost", "dep:prost-types", "dep:prost-build"]
 
+# This feature provides additional interfaces for testing.
+#
+# NB: Interfaces gated by this feature flag are not subject to stability
+# guarantees and may be changed or removed in patch releases.
+test-util = []
+
 [workspace]
 members = ["derive-encode"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,12 @@
 //! ```
 //! See [examples] directory for more.
 //!
+//! # Features
+//!
+//! The `test-util` gates additional interfaces, such as accessors, to facilitate integration and
+//! unit testing of metrics. Note that interfaces gated by this feature flag are not subject to
+//! stability guarantees and may be changed or removed in patch releases.
+//!
 //! [examples]: https://github.com/prometheus/client_rust/tree/master/examples
 
 pub mod collector;


### PR DESCRIPTION
for background, see discussion in #242:

> > Would you be amenable to feature-gating these public helpers behind
> > a `test-util` feature? This is a pretty common approach we've seen
> > in other crates.
>
> That sounds reasonable to me. Contribution welcome. Thanks. Please
> point out very prominently that we might break any of those APIs in
> a patch release.

\- <https://github.com/prometheus/client_rust/pull/242#issuecomment-3245089740>

this commit introduces a `test-util` feature flag.

this feature flag will function as a gate for additional interfaces, such as accessors to read the value of a histogram, that facilitate integration tests inspecting metrics.

comments note that any forthcoming interfaces included by this feature are not subject to stability guarantees.