### PR TITLE
feat(example): add an axum example with a global registry and a global metric

### DIFF
--- a/examples/axum_with_globals.rs
+++ b/examples/axum_with_globals.rs
@@ -19,7 +19,7 @@ use tokio::time;
 
 static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
 
-fn register_metric_to_global_registry<MetricType: Metric + Clone + Default>(
+pub fn register_metric_to_global_registry<MetricType: Metric + Clone + Default>(
     name: &str,
     help: &str,
 ) -> MetricType {
@@ -31,7 +31,7 @@ fn register_metric_to_global_registry<MetricType: Metric + Clone + Default>(
     metric
 }
 
-async fn metrics_handler() -> impl IntoResponse {
+pub async fn metrics_handler() -> impl IntoResponse {
     let mut buffer = String::new();
     {
         let registry = REGISTRY

--- a/examples/axum_with_globals.rs
+++ b/examples/axum_with_globals.rs
@@ -24,9 +24,9 @@ fn register_metric_to_global_registry<MetricType: Metric + Clone + Default>(
     help: &str,
 ) -> MetricType {
     let metric: MetricType = MetricType::default();
-    let mut registry = REGISTRY.lock().expect(&format!(
-        "Cannot lock metrics registry to create {name} metric"
-    ));
+    let mut registry = REGISTRY
+        .lock()
+        .unwrap_or_else(|_| panic!("Cannot lock metrics registry to create {name} metric"));
     registry.register(name, help, metric.clone());
     metric
 }
@@ -84,7 +84,9 @@ async fn main() {
         .await
         .unwrap();
 
-    tokio::join!(axum::serve(listener, router), background_task());
+    let (listener, _background_task) =
+        tokio::join!(axum::serve(listener, router), background_task());
+    listener.unwrap()
 }
 
 async fn background_task() {

--- a/examples/axum_with_globals.rs
+++ b/examples/axum_with_globals.rs
@@ -1,53 +1,49 @@
-use axum::response::IntoResponse;
-use axum::routing::get;
-use axum::Router;
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
+use axum::{
+    body::Body,
+    http::{header::CONTENT_TYPE, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use prometheus_client::{
+    encoding::text::encode,
+    metrics::{counter::Counter, family::Family},
+    registry::{Metric, Registry},
+};
 use prometheus_client_derive_encode::{EncodeLabelSet, EncodeLabelValue};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
 
-//A separate module (usually in a seperate file) to scope the registry
-mod metrics {
-    use axum::body::Body;
-    use axum::http::header::CONTENT_TYPE;
-    use axum::http::StatusCode;
-    use axum::response::{IntoResponse, Response};
-    use prometheus_client::encoding::text::encode;
-    use prometheus_client::registry::{Metric, Registry};
-    use std::sync::{LazyLock, Mutex};
+static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
 
-    static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
+fn register_metric_to_global_registry<MetricType: Metric + Clone + Default>(
+    name: &str,
+    help: &str,
+) -> MetricType {
+    let metric: MetricType = MetricType::default();
+    let mut registry = REGISTRY.lock().expect(&format!(
+        "Cannot lock metrics registry to create {name} metric"
+    ));
+    registry.register(name, help, metric.clone());
+    metric
+}
 
-    pub fn register_metric_to_global_registry<MetricType: Metric + Clone + Default>(
-        name: &str,
-        help: &str,
-    ) -> MetricType {
-        let metric: MetricType = MetricType::default();
-        let mut registry = REGISTRY.lock().expect(&format!(
-            "Cannot lock metrics registry to create {name} metric"
-        ));
-        registry.register(name, help, metric.clone());
-        metric
+async fn metrics_handler() -> impl IntoResponse {
+    let mut buffer = String::new();
+    {
+        let registry = REGISTRY
+            .lock()
+            .expect("could not acquire a lock on registry to push metrics");
+        encode(&mut buffer, &registry).unwrap();
     }
 
-    pub async fn metrics_handler() -> impl IntoResponse {
-        let mut buffer = String::new();
-        {
-            let registry = REGISTRY
-                .lock()
-                .expect("could not acquire a lock on registry to push metrics");
-            encode(&mut buffer, &registry).unwrap();
-        }
-
-        Response::builder()
-            .status(StatusCode::OK)
-            .header(
-                CONTENT_TYPE,
-                "application/openmetrics-text; version=1.0.0; charset=utf-8",
-            )
-            .body(Body::from(buffer))
-            .unwrap()
-    }
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
+        .body(Body::from(buffer))
+        .unwrap()
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
@@ -62,7 +58,7 @@ pub struct MethodLabels {
 }
 
 static METRIC: LazyLock<Family<MethodLabels, Counter>> =
-    LazyLock::new(|| metrics::register_metric_to_global_registry("requests", "Count of requests"));
+    LazyLock::new(|| register_metric_to_global_registry("requests", "Count of requests"));
 
 pub async fn some_handler() -> impl IntoResponse {
     METRIC
@@ -76,7 +72,7 @@ pub async fn some_handler() -> impl IntoResponse {
 #[tokio::main]
 async fn main() {
     let router = Router::new()
-        .route("/metrics", get(metrics::metrics_handler))
+        .route("/metrics", get(metrics_handler))
         .route("/handler", get(some_handler));
     let port = 8080;
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))

--- a/examples/axum_with_globals.rs
+++ b/examples/axum_with_globals.rs
@@ -1,0 +1,87 @@
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prometheus_client_derive_encode::{EncodeLabelSet, EncodeLabelValue};
+use std::sync::LazyLock;
+
+//A separate module (usually in a seperate file) to scope the registry
+mod metrics {
+    use axum::body::Body;
+    use axum::http::header::CONTENT_TYPE;
+    use axum::http::StatusCode;
+    use axum::response::{IntoResponse, Response};
+    use prometheus_client::encoding::text::encode;
+    use prometheus_client::registry::{Metric, Registry};
+    use std::sync::{LazyLock, Mutex};
+
+    static REGISTRY: LazyLock<Mutex<Registry>> = LazyLock::new(|| Mutex::new(Registry::default()));
+
+    pub fn register_metric_to_global_registry<MetricType: Metric + Clone + Default>(
+        name: &str,
+        help: &str,
+    ) -> MetricType {
+        let metric: MetricType = MetricType::default();
+        let mut registry = REGISTRY.lock().expect(&format!(
+            "Cannot lock metrics registry to create {name} metric"
+        ));
+        registry.register(name, help, metric.clone());
+        metric
+    }
+
+    pub async fn metrics_handler() -> impl IntoResponse {
+        let mut buffer = String::new();
+        {
+            let registry = REGISTRY
+                .lock()
+                .expect("could not acquire a lock on registry to push metrics");
+            encode(&mut buffer, &registry).unwrap();
+        }
+
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(
+                CONTENT_TYPE,
+                "application/openmetrics-text; version=1.0.0; charset=utf-8",
+            )
+            .body(Body::from(buffer))
+            .unwrap()
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub enum Method {
+    Get,
+    Post,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct MethodLabels {
+    pub method: Method,
+}
+
+static METRIC: LazyLock<Family<MethodLabels, Counter>> =
+    LazyLock::new(|| metrics::register_metric_to_global_registry("requests", "Count of requests"));
+
+pub async fn some_handler() -> impl IntoResponse {
+    METRIC
+        .get_or_create(&MethodLabels {
+            method: Method::Get,
+        })
+        .inc();
+    "okay".to_string()
+}
+
+#[tokio::main]
+async fn main() {
+    let router = Router::new()
+        .route("/metrics", get(metrics::metrics_handler))
+        .route("/handler", get(some_handler));
+    let port = 8080;
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+        .await
+        .unwrap();
+
+    axum::serve(listener, router).await.unwrap();
+}


### PR DESCRIPTION
I am currently migrating a large project from [prometheus](https://github.com/tikv/rust-prometheus) to this crate.

Given the high volume of metrics and the variety of tasks in our project, we have opted for a **global registry and global metrics**. I have modified the [examples/axum.rs](https://github.com/prometheus/client_rust/blob/master/examples/axum.rs) example to demonstrate this pattern and provide a reference for other users.

1. Are there any improvements or best practices you would suggest for this example?
2. Are there potential changes to the library that could better support this specific use case?