### PR TITLE
protobuf: allow compiling without protoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,9 @@ The `build.rs` script in this library depends upon the
 [Protocol Buffers compiler][protoc]. Be sure that `protoc` is installed and
 available within your `PATH`.
 
+If you enable the off-by-default `protobuf-protox` feature, the build uses
+`protox` instead and does not require `protoc`.
+
 [protoc]: https://docs.rs/prost-build/latest/prost_build/#sourcing-protoc
 
 ## Python Dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ dtoa = "1.0"
 itoa = "1.0"
 parking_lot = "0.12"
 prometheus-client-derive-encode = { version = "0.5.0", path = "derive-encode" }
-prost = { version = "0.12.0", optional = true }
-prost-types = { version = "0.12.0", optional = true }
+prost = { version = "0.14", optional = true }
+prost-types = { version = "0.14", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
@@ -49,7 +49,7 @@ hyper-util = { version = "0.1.3", features = ["tokio"] }
 http-body-util = "0.1.1"
 
 [build-dependencies]
-prost-build = { version = "0.12.0", optional = true }
+prost-build = { version = "0.14", optional = true }
 
 [[bench]]
 name = "baseline"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/prometheus-client"
 [features]
 default = []
 protobuf = ["dep:prost", "dep:prost-types", "dep:prost-build"]
+protobuf-protox = ["protobuf", "dep:protox"]
 
 # This feature provides additional APIs for testing downstream code using
 # `prometheus-client`.
@@ -50,6 +51,7 @@ http-body-util = "0.1.1"
 
 [build-dependencies]
 prost-build = { version = "0.14", optional = true }
+protox = { version = "0.9.1", optional = true }
 
 [[bench]]
 name = "baseline"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,22 @@
-use std::io::Result;
+use std::error::Error;
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     #[cfg(feature = "protobuf")]
-    prost_build::compile_protos(
-        &["src/encoding/proto/openmetrics_data_model.proto"],
-        &["src/encoding/proto/"],
-    )?;
+    compile_protos()?;
+
+    Ok(())
+}
+
+#[cfg(feature = "protobuf")]
+fn compile_protos() -> Result<(), Box<dyn Error>> {
+    let protos = ["src/encoding/proto/openmetrics_data_model.proto"];
+    let includes = ["src/encoding/proto/"];
+
+    #[cfg(feature = "protobuf-protox")]
+    prost_build::compile_fds(protox::compile(protos, includes)?)?;
+
+    #[cfg(not(feature = "protobuf-protox"))]
+    prost_build::compile_protos(&protos, &includes)?;
 
     Ok(())
 }


### PR DESCRIPTION
Our goal is to have our builds compile without external dependencies.
`protox` helps achieve this.