### PR TITLE
ci: add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Keep the existing cargo updates and add github-actions so Dependabot keeps maintained CI actions current. Avoids adopting PR #308, which would have dropped the cargo ecosystem and added Go-specific config irrelevant to this Rust crate.