### PR TITLE
(ci): replace archived actions-rs actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,11 +12,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       # Install prometheus_client python library.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -36,15 +34,9 @@ jobs:
           path: ~/.cargo/git
           key: cargo-index-${{ hashFiles('Cargo.toml') }}
 
-      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
-        with:
-          command: check
-          args: --locked
+      - run: cargo check --locked
 
-      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
-        with:
-          command: test
-          args: --locked --benches --all-features
+      - run: cargo test --locked --benches --all-features
 
   test:
     name: Test Suite
@@ -55,11 +47,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       # Install prometheus_client python library.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -79,30 +69,18 @@ jobs:
           path: ~/.cargo/git
           key: cargo-index-${{ hashFiles('Cargo.toml') }}
 
-      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
-        with:
-          command: test
-          args: --locked --all --all-features
+      - run: cargo test --locked --all --all-features
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -113,12 +91,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - run: rustup component add clippy
+          components: clippy
 
       # Caching
       - name: Cache cargo registry
@@ -132,10 +108,7 @@ jobs:
           path: ~/.cargo/git
           key: cargo-index-${{ hashFiles('Cargo.toml') }}
 
-      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
-        with:
-          command: clippy
-          args: --locked --workspace --all-targets -- -D warnings
+      - run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
   check-rustdoc-links:
     name: Check rustdoc intra-doc links
@@ -146,17 +119,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
+      - run: cargo doc --locked --verbose --workspace --no-deps --document-private-items --all-features
         env:
           RUSTDOCFLAGS: "--deny broken_intra_doc_links"
-        with:
-          command: doc
-          args: --locked --verbose --workspace --no-deps --document-private-items --all-features
 
   cross-compile:
     name: Cross compile


### PR DESCRIPTION
`actions-rs/toolchain` and `actions-rs/cargo` are both archived and still on `node12`, so dependabot keeps opening PRs to bump it, see #318.

This PR replaces them with `dtolnay/rust-toolchain`, which is already pinned at the same SHA in the cross-compile job, so no new dependency.
All six cargo commands are unchanged, `profile: minimal`/`override: true` are what dtolnay does by default, and `rustup component add` folds into `components:`.

Also dropped the protoc install from the Rustfmt job, since `cargo fmt` never builds anything.

Job names are untouched so the checks report exactly as before. Only downside: we losethe inline error annotations `actions-rs/cargo` gave us, but errors are still in the logs.

Closes #318.