### PR TITLE
ci: avoid duplicate runs, harden checkout, use rust-cache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v*"
   pull_request:
 
 name: Continuous integration
@@ -12,8 +14,9 @@ permissions:
 concurrency:
   # GitHub concurrency keeps at most one running and one pending run per group.
   # Use ref_name for PRs so new commits cancel older PR runs on the same PR,
-  # but key pushes by SHA so postsubmit runs do not cancel each other.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.ref_name) || format('push-{0}', github.sha) }}
+  # but key pushes by ref and SHA so postsubmit runs do not cancel each other,
+  # and a release tag does not queue behind the master run for the same commit.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.ref_name) || format('push-{0}-{1}', github.ref, github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,20 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 name: Continuous integration
+
+permissions:
+  contents: read
+
+concurrency:
+  # GitHub concurrency keeps at most one running and one pending run per group.
+  # Use ref_name for PRs so new commits cancel older PR runs on the same PR,
+  # but key pushes by SHA so postsubmit runs do not cancel each other.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.ref_name) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:
@@ -12,27 +26,21 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Don't let pull request branches evict the master cache.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # Install prometheus_client python library.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
       - run: pip3 install prometheus_client
-
-      # Caching
-      - name: Cache cargo registry
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ hashFiles('Cargo.toml') }}
-      - name: Cache cargo index
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ hashFiles('Cargo.toml') }}
 
       - run: cargo check --locked
 
@@ -47,27 +55,21 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Don't let pull request branches evict the master cache.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # Install prometheus_client python library.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
       - run: pip3 install prometheus_client
-
-      # Caching
-      - name: Cache cargo registry
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ hashFiles('Cargo.toml') }}
-      - name: Cache cargo index
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ hashFiles('Cargo.toml') }}
 
       - run: cargo test --locked --all --all-features
 
@@ -76,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
@@ -91,22 +95,16 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           components: clippy
-
-      # Caching
-      - name: Cache cargo registry
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ hashFiles('Cargo.toml') }}
-      - name: Cache cargo index
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ hashFiles('Cargo.toml') }}
+          # Don't let pull request branches evict the master cache.
+          save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
@@ -119,6 +117,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
@@ -138,6 +138,8 @@ jobs:
           - wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:


### PR DESCRIPTION
`on: [push, pull_request]` ran every job twice for branches pushed to this repo, which is every dependabot PR, each `dependabot/*` branch has a 1 pair of `push` and `pull_request` runs per commit.

This PR:

- Scopes `push` to `master` and `v*`, and adds a concurrency group, so superseded pull request runs are cancelled while postsubmit runs on `master` (keyed by SHA) never cancel each other. No required status check depends on the `push` event, and the README badge (`?event=push`) still resolves, since pushes to `master` continue to fire.
- Sets `persist-credentials: false` on every checkout and declares `permissions: contents: read`. Neither is needed by any step here — nothing pushes, and `setup-protoc` receives its token through an explicit `repo-token:` input rather than from git config. This matters a little more than usual because `cargo test --all-features` executes `build.rs` from every dependency in the tree.
- Replaces `actions/cache` with `Swatinem/rust-cache`. The old key hashed `Cargo.toml` and not `Cargo.lock`, so lockfile-only dependabot PRs restored a cache built from a different dependency set, and `target/` was never cached at all. `save-if` limits saving to `master` so pull request branches cannot evict its cache. Pinned to `c1937114`, the `v2.9.1` release commit, per this repo's SHA-pin convention.

Fork PRs were already unaffected, their `push` fires in the fork, so the duplicate-run fix is not observable on this PR. It will show on the next dependabot PR.
