### PR TITLE
ci: group and rate-limit dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,32 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    groups:
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      cargo-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This PR
  - groups updates
    -  Cargo gets two groups: one for patch+minor, one for majors. Majors are split out because a group is only as mergeable as its worst member; a major we don't want yet would otherwise sit there blocking a pile of harmless patch bumps
  - switches to weekly from daily for cargo. Daily + grouped still churns
  - adds a 7-day cooldown, so we get proposed settled versions rather than same-week releases.
  - adds PR limits
    -  2 for cargo (one per group), 1 for github-actions. Security updates aren't subject to the limit
  - groups github-actions too
    -  Four separate PRs touching `rust.yml` last week gave us an adjacent-line conflict for no reason