### PR TITLE
benches: use std::hint::black_box

### DIFF
--- a/benches/encoding/proto.rs
+++ b/benches/encoding/proto.rs
@@ -1,13 +1,14 @@
 // Benchmark inspired by
 // https://github.com/tikv/rust-prometheus/blob/ab1ca7285d3463504381a5025ae1951e020d6796/benches/text_encoder.rs:write
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use prometheus_client::encoding::prometheus_protobuf;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
 use prometheus_client::registry::Registry;
 use prometheus_client_derive_encode::{EncodeLabelSet, EncodeLabelValue};
+use std::hint::black_box;
 
 pub fn proto(c: &mut Criterion) {
     c.bench_function("encode", |b| {

--- a/benches/encoding/text.rs
+++ b/benches/encoding/text.rs
@@ -1,12 +1,13 @@
 // Benchmark inspired by https://github.com/tikv/rust-prometheus/blob/ab1ca7285d3463504381a5025ae1951e020d6796/benches/text_encoder.rs
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use prometheus_client::encoding::{self, EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::{exponential_buckets, Histogram};
 use prometheus_client::registry::Registry;
 use std::fmt::Write;
+use std::hint::black_box;
 
 pub fn text(c: &mut Criterion) {
     c.bench_function("encode", |b| {

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -1,7 +1,8 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use prometheus_client::metrics::histogram::{
     exponential_buckets, Histogram, NativeHistogramConfig,
 };
+use std::hint::black_box;
 
 const OBSERVATION: f64 = 64.0;
 


### PR DESCRIPTION
criterion 0.8 deprecates `criterion::black_box` in favour of the std function it re-exports, see failures in https://github.com/prometheus/client_rust/actions/runs/30914192889/job/92008038237?pr=333

This PR switches to `std::hint::black_box`, which is stable since 1.66 and works with both criterion 0.5 and 0.8 thus unblocking https://github.com/prometheus/client_rust/pull/333