### PR TITLE
fix(encoding): use +Inf as the implicit histogram overflow bucket bound

### DIFF
--- a/src/encoding/prometheus_protobuf.rs
+++ b/src/encoding/prometheus_protobuf.rs
@@ -803,7 +803,11 @@ mod tests {
         assert_eq!(11, histogram.bucket.len());
         assert_eq!(1, histogram.bucket[0].cumulative_count);
         assert_eq!(1.0, histogram.bucket[0].upper_bound);
-        assert_eq!(f64::MAX, histogram.bucket.last().unwrap().upper_bound);
+        assert_eq!(
+            f64::INFINITY,
+            histogram.bucket.last().unwrap().upper_bound,
+            "the implicit overflow bucket must be exposed as +Inf"
+        );
     }
 
     #[test]

--- a/src/encoding/text.rs
+++ b/src/encoding/text.rs
@@ -426,7 +426,7 @@ impl MetricEncoder<'_> {
             self.write_prefix_name_unit()?;
             self.write_suffix("bucket")?;
 
-            if *upper_bound == f64::MAX {
+            if *upper_bound == f64::INFINITY {
                 self.encode_labels(Some(&[("le", "+Inf")]))?;
             } else {
                 self.encode_labels(Some(&[("le", *upper_bound)]))?;

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -2238,18 +2238,33 @@ mod tests {
 mod overflow_bucket_tests {
     use super::Histogram;
 
-    /// An `+Inf` observation must land in the overflow bucket.
-    ///
-    /// `observe_classic` routes NaN to the last bucket explicitly, but everything else through
-    /// `find(|(upper_bound, _)| upper_bound >= &v)`. With `f64::MAX` as the sentinel,
-    /// `f64::MAX >= f64::INFINITY` is false, so an infinite observation incremented `sum` and
-    /// `count` while incrementing NO bucket — leaving the overflow bucket short of `_count`.
-    /// Prometheus only hid this because it ignored the finite sentinel and synthesised its own
-    /// `+Inf` series from `sample_count`.
-    /// An explicitly-configured `+Inf` bound must not duplicate the implicit overflow bucket.
-    ///
-    /// Two buckets with the same `le` is invalid exposition, so `Histogram::new` drops non-finite
-    /// bounds, as `client_golang` does.
+    /// Every observation, including `+Inf` and `NaN`, must be counted in some bucket.
+    #[test]
+    fn infinite_observation_lands_in_the_overflow_bucket() {
+        let histogram = Histogram::new([1.0, 2.0]);
+        histogram.observe(0.5);
+        histogram.observe(f64::INFINITY);
+        histogram.observe(f64::NAN);
+
+        let inner = histogram.inner.lock();
+        let cumulative: u64 = inner.buckets.iter().map(|(_, count)| count).sum();
+        assert_eq!(
+            cumulative, inner.count,
+            "every observation must be in some bucket; buckets={:?} count={}",
+            inner.buckets, inner.count
+        );
+        let (last_bound, last_count) = *inner.buckets.last().expect("no buckets");
+        assert!(
+            last_bound.is_infinite(),
+            "overflow bound is {last_bound:e}, not +Inf"
+        );
+        assert_eq!(
+            last_count, 2,
+            "the +Inf and NaN observations belong to the overflow bucket"
+        );
+    }
+
+    /// An explicit `+Inf` bound must not duplicate the implicit overflow bucket.
     #[test]
     fn explicit_infinite_bound_does_not_duplicate_the_overflow_bucket() {
         use crate::encoding::text::encode;
@@ -2286,31 +2301,6 @@ mod overflow_bucket_tests {
             encoded.matches(r#"le="+Inf""#).count(),
             1,
             "the exposition must contain exactly one +Inf bucket:\n{encoded}"
-        );
-    }
-
-    #[test]
-    fn infinite_observation_lands_in_the_overflow_bucket() {
-        let histogram = Histogram::new([1.0, 2.0]);
-        histogram.observe(0.5);
-        histogram.observe(f64::INFINITY);
-        histogram.observe(f64::NAN);
-
-        let inner = histogram.inner.lock();
-        let cumulative: u64 = inner.buckets.iter().map(|(_, count)| count).sum();
-        assert_eq!(
-            cumulative, inner.count,
-            "every observation must be in some bucket; buckets={:?} count={}",
-            inner.buckets, inner.count
-        );
-        let (last_bound, last_count) = *inner.buckets.last().expect("no buckets");
-        assert!(
-            last_bound.is_infinite(),
-            "overflow bound is {last_bound:e}, not +Inf"
-        );
-        assert_eq!(
-            last_count, 2,
-            "the +Inf and NaN observations belong to the overflow bucket"
         );
     }
 }

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -323,7 +323,7 @@ impl Histogram {
                 count: Default::default(),
                 buckets: buckets
                     .into_iter()
-                    .chain(once(f64::MAX))
+                    .chain(once(f64::INFINITY))
                     .map(|upper_bound| (upper_bound, 0))
                     .collect(),
                 native: None,
@@ -2224,6 +2224,44 @@ mod tests {
         assert_eq!(
             2,
             native.positive.iter().map(|(_, count)| *count).sum::<u64>()
+        );
+    }
+}
+
+#[cfg(test)]
+mod overflow_bucket_tests {
+    use super::Histogram;
+
+    /// An `+Inf` observation must land in the overflow bucket.
+    ///
+    /// `observe_classic` routes NaN to the last bucket explicitly, but everything else through
+    /// `find(|(upper_bound, _)| upper_bound >= &v)`. With `f64::MAX` as the sentinel,
+    /// `f64::MAX >= f64::INFINITY` is false, so an infinite observation incremented `sum` and
+    /// `count` while incrementing NO bucket — leaving the overflow bucket short of `_count`.
+    /// Prometheus only hid this because it ignored the finite sentinel and synthesised its own
+    /// `+Inf` series from `sample_count`.
+    #[test]
+    fn infinite_observation_lands_in_the_overflow_bucket() {
+        let histogram = Histogram::new([1.0, 2.0]);
+        histogram.observe(0.5);
+        histogram.observe(f64::INFINITY);
+        histogram.observe(f64::NAN);
+
+        let inner = histogram.inner.lock();
+        let cumulative: u64 = inner.buckets.iter().map(|(_, count)| count).sum();
+        assert_eq!(
+            cumulative, inner.count,
+            "every observation must be in some bucket; buckets={:?} count={}",
+            inner.buckets, inner.count
+        );
+        let (last_bound, last_count) = *inner.buckets.last().expect("no buckets");
+        assert!(
+            last_bound.is_infinite(),
+            "overflow bound is {last_bound:e}, not +Inf"
+        );
+        assert_eq!(
+            last_count, 2,
+            "the +Inf and NaN observations belong to the overflow bucket"
         );
     }
 }

--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -316,6 +316,11 @@ impl Histogram {
     /// # use prometheus_client::metrics::histogram::Histogram;
     /// let histogram = Histogram::new([10.0, 100.0, 1_000.0]);
     /// ```
+    ///
+    /// The overflow bucket is implicit and always present, so non-finite bounds in `buckets` are
+    /// dropped: passing `f64::INFINITY` explicitly would otherwise produce two `le="+Inf"` series
+    /// for the same metric. `client_golang` strips an explicitly-configured `+Inf` bound for the
+    /// same reason. A `NaN` bound is dropped too, since no observation can ever match it.
     pub fn new(buckets: impl IntoIterator<Item = f64>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(Inner {
@@ -323,6 +328,7 @@ impl Histogram {
                 count: Default::default(),
                 buckets: buckets
                     .into_iter()
+                    .filter(|upper_bound| upper_bound.is_finite())
                     .chain(once(f64::INFINITY))
                     .map(|upper_bound| (upper_bound, 0))
                     .collect(),
@@ -2240,6 +2246,49 @@ mod overflow_bucket_tests {
     /// `count` while incrementing NO bucket — leaving the overflow bucket short of `_count`.
     /// Prometheus only hid this because it ignored the finite sentinel and synthesised its own
     /// `+Inf` series from `sample_count`.
+    /// An explicitly-configured `+Inf` bound must not duplicate the implicit overflow bucket.
+    ///
+    /// Two buckets with the same `le` is invalid exposition, so `Histogram::new` drops non-finite
+    /// bounds, as `client_golang` does.
+    #[test]
+    fn explicit_infinite_bound_does_not_duplicate_the_overflow_bucket() {
+        use crate::encoding::text::encode;
+        use crate::registry::Registry;
+
+        let histogram = Histogram::new([1.0, f64::INFINITY, f64::NAN, f64::NEG_INFINITY]);
+        histogram.observe(0.5);
+
+        {
+            let inner = histogram.inner.lock();
+            let infinite = inner
+                .buckets
+                .iter()
+                .filter(|(upper_bound, _)| upper_bound.is_infinite())
+                .count();
+            assert_eq!(
+                infinite, 1,
+                "exactly one infinite bucket expected, got buckets={:?}",
+                inner.buckets
+            );
+            assert_eq!(
+                inner.buckets.len(),
+                2,
+                "only the finite 1.0 bound plus the implicit overflow bucket should remain, got {:?}",
+                inner.buckets
+            );
+        }
+
+        let mut registry = Registry::default();
+        registry.register("my_histogram", "My histogram", histogram);
+        let mut encoded = String::new();
+        encode(&mut encoded, &registry).expect("encode");
+        assert_eq!(
+            encoded.matches(r#"le="+Inf""#).count(),
+            1,
+            "the exposition must contain exactly one +Inf bucket:\n{encoded}"
+        );
+    }
+
     #[test]
     fn infinite_observation_lands_in_the_overflow_bucket() {
         let histogram = Histogram::new([1.0, 2.0]);


### PR DESCRIPTION
## What

`Histogram::new` appends `f64::MAX` as the sentinel for the implicit overflow bucket, and only
`encoding::text` translates it back to `le="+Inf"`. Both protobuf encoders ship it verbatim, so
consumers receive an overflow bucket whose upper bound is `1.7976931348623157e+308` — a very large
*finite* bound, not an infinity.

This changes the sentinel to `f64::INFINITY` rather than translating it in each encoder.
`Histogram::new` is the only construction site (`new_classic_and_native` and
`HistogramWithExemplars::new` both delegate to it), so one line covers classic, exemplar and
classic+native histograms; the protobuf encoders then need no special case, and the text encoder
only changes what it compares against.

## Why it matters

**1. Quantiles above the ladder return ~1e308.** Prometheus recognises the +Inf bucket with
`IsInf`, so it never saw one: it ingested the sentinel as an ordinary finite bucket and synthesised
its own `le="+Inf"` series from `sample_count`. promql's `bucketQuantile` never interpolates into
the +Inf bucket and returns the second-highest bound instead — the sentinel. Every quantile above
the histogram's real ladder therefore returned ~1.1e308 instead of a value. Measured on 0.25.0
scraped by Grafana Alloy into Mimir, `histogram_quantile(0.99, ...)` returned
`1.0968850044231772e+308`, which Grafana renders as "5.58e+300 years". It is silent: the series
scrapes cleanly and the panel only goes wrong once a quantile saturates. Scraping protobuf is not
optional for anyone using native histograms, since that is the only exposition offering them.

**2. `+Inf` observations were counted in no bucket.** `observe_classic` routes NaN to the last
bucket explicitly, but everything else through `find(|(upper_bound, _)| upper_bound >= &v)`.
Since `f64::MAX >= f64::INFINITY` is false, an infinite observation incremented `sum` and `count`
while incrementing no bucket at all, leaving the overflow bucket short of `_count`. Prometheus's
synthetic +Inf series masked that too. Fixing only the encoders would have made this short count
visible rather than fixing it.

**3. An explicit `+Inf` bound would now duplicate the overflow bucket.** Because the sentinel is
real infinity, `Histogram::new([1.0, f64::INFINITY])` would emit two `le="+Inf"` series for one
metric — invalid exposition. `Histogram::new` therefore drops non-finite bounds from the caller's
`buckets`; `client_golang` strips an explicitly-configured `+Inf` bound for the same reason. `NaN`
and `-Inf` bounds are dropped too: a `NaN` bound can never match an observation, since every
comparison against it is false.

## Why +Inf is the correct value

- `metrics.proto` documents this field as holding a "+Inf bucket" (optional, inclusive).
- `client_golang` writes `math.Inf(1)` whenever it emits that bucket, and Prometheus branches on
  `math.IsInf`.
- The OpenMetrics spec requires a Histogram MetricPoint to have a bucket with an `+Inf` threshold,
  so the OpenMetrics encoder was in outright violation.
- prost encodes `double` as a raw IEEE-754 fixed64, so infinity is bit-exact on the wire
  (`00 00 00 00 00 00 F0 7F`) and decodes back to +Inf on the Go side.

The native-histogram `positive_upper_bound` returning `f64::MAX` is deliberately left alone — it
mirrors client_golang's `getBound` and is not on any wire path.

## Testing

Two regression tests, each verified to fail without the corresponding half of the change:

- every observation, including `+Inf` and `NaN`, is counted in some bucket. Fails before this
  change with `buckets=[(1.0, 1), (2.0, 0), (1.7976931348623157e308, 1)] count=3`.
- an explicit `+Inf` bound does not duplicate the overflow bucket, asserted both on the bucket list
  and on the rendered text exposition. Fails without the filter with
  `buckets=[(1.0, 1), (inf, 0), (NaN, 0), (-inf, 0), (inf, 0)]`.

`cargo fmt --all -- --check` is clean, `cargo clippy --locked --workspace --all-targets -- -D warnings`
reports nothing, and `cargo test --locked --all --all-features` passes 92/92 with the Python
`prometheus-client` dependency from CONTRIBUTING.md installed.
